### PR TITLE
docs: remove backticks from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ require("neotest").setup({
   }
 })
 ```
-```
 
 This is currently in development, here is a roadmap of planned support for this plugin and the current status
 


### PR DESCRIPTION
this was breaking my tables

Fixes N/A