### PR TITLE
fix(build_spec): correctly identify root

### DIFF
--- a/lua/neotest-kotest.lua
+++ b/lua/neotest-kotest.lua
@@ -11,7 +11,7 @@ local output_parser = require("src.output-parser")
 local adapter = { name = "neotest-kotest" }
 
 function adapter.root(dir)
-  return lib.files.match_root_pattern("build.gradle.kts")(dir)
+  return lib.files.match_root_pattern("gradlew")(dir)
 end
 
 function adapter.filter_dir(name, rel_path, root)


### PR DESCRIPTION
assuming this is a gradle project, we will now
look for the gradlew executable rather than the build.gradle.kts this will be backwards compatible with groovy configurations, and also just makes more sense in general since they don't need to be in the same directory and the new gradle init seems to put them in different places anyway.

Fixes: #26