### PR TITLE
feat: add kotest FunSpec treesitter-query

### DIFF
--- a/lua/src/treesitter/spec-query.lua
+++ b/lua/src/treesitter/spec-query.lua
@@ -68,7 +68,65 @@ M.value = [[
     )
 ) @test.definition
 
-;; -- todo FUN SPEC --
+;; -- FUN SPEC --
+; Matches test("context") { /** body **/ }
+(call_expression
+	(call_expression
+	  (simple_identifier) @func_name (#eq? @func_name "test")
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (string_literal) @test.name
+          )
+        )
+      )
+    )
+  ) @test.definition
+
+; Matches xtest("context") { /** body **/ }
+(call_expression
+	(call_expression
+	  (simple_identifier) @func_name (#eq? @func_name "xtest")
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (string_literal) @test.name
+          )
+        )
+      )
+    )
+  ) @test.definition
+
+; Matches namespace xcontext("context") { /** body **/ }
+
+(call_expression
+  (call_expression
+    (simple_identifier) @func_name (#eq? @func_name "xcontext")
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (string_literal) @namespace.name
+          )
+        )
+      )
+    )
+  ) @namespace.definition
+
+; Matches namespace context("context") { /** body **/ }
+
+(call_expression
+	(call_expression
+	  (simple_identifier) @func_name (#eq? @func_name "context")
+      (call_suffix
+        (value_arguments
+          (value_argument
+            (string_literal) @namespace.name
+          )
+        )
+      )
+    )
+) @namespace.definition
+
 ;; -- todo SHOULD SPEC --
 ;; -- todo STRING SPEC --
 ;; -- todo BEHAVIOR SPEC --

--- a/test.kt
+++ b/test.kt
@@ -1,13 +1,29 @@
 import io.kotest.core.spec.style.DescribeSpec
 
-class CoolTest : DescribeSpec({
+class CoolTest :
+    DescribeSpec({
 
-  describe("a cool test") {
-    
-    it("should do something cool") {
-  
-    }
-  
-  }
+        describe("a cool test") {
 
-})
+            it("should do something cool") {
+            }
+        }
+    })
+
+class FunTests :
+    FunSpec({
+        test("String length should return the length of the string") {
+            "sammy".length shouldBe 5
+            "".length shouldBe 0
+        }
+        context("this outer block is enabled") {
+            xtest("this test is disabled") {
+                // test here
+            }
+        }
+        xcontext("this block is disabled") {
+            test("disabled by inheritance from the parent") {
+                // test here
+            }
+        }
+    })


### PR DESCRIPTION
Resolves #6

Adds the FunSpec ts-query including an updated test for it (Also my formatter formatted the previous existing test, so don't worry). Tests are pulled from kotest docs btw.