### PR TITLE
Fix output parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /lua/tests/example_project/gradle/wrapper/**
+.luarc.json

--- a/lua/neotest-kotlin/init.lua
+++ b/lua/neotest-kotlin/init.lua
@@ -95,7 +95,7 @@ function M.Adapter.build_spec(args)
     stream = function()
       return function()
         local new_results = stream_data()
-        local success, parsed_result = pcall(output_parser.lines_to_results, new_results, pos.path, specPackage)
+        local success, parsed_result = pcall(output_parser.parse_lines, new_results, pos.path, specPackage)
         if not success then
           print("An error ocurred while attempting to stream data to result: " ..
             vim.inspect(err) .. " new_results: " .. vim.inspect(new_results))

--- a/lua/neotest-kotlin/src/command.lua
+++ b/lua/neotest-kotlin/src/command.lua
@@ -1,15 +1,25 @@
 local M = {}
 
--- tests is the name of the test block
--- specs is the package name of the file you are interpreting
--- outfile is where the test output will be written to.
+---Constructs the gradle command to execute
+---@param tests string the name of the test block
+---@param specs string the package name of the file you are interpreting
+---@param outfile string where the test output will be written to.
+---@return string command the gradle command to execute
 M.parse = function(tests, specs, outfile)
-  return "export kotest_filter_tests='"
-      .. tests
-      .. "'; export kotest_filter_specs='"
-      .. specs
-      .. "'; ./gradlew cleanTest test --debug --console=plain | tee -a "
-      .. outfile
+	local INIT_SCRIPT_NAME = "test-logging.init.gradle.kts"
+
+	local init_script_path = vim.api.nvim_get_runtime_file(INIT_SCRIPT_NAME, false)[1]
+	if init_script_path == nil then
+		error(string.format("failed to find '%s' in runtime path", INIT_SCRIPT_NAME))
+	end
+
+	return string.format(
+		"kotest_filter_specs='%s' kotest_filter_tests='%s' ./gradlew -I %s test --console=plain | tee -a %s",
+		specs,
+		tests,
+		init_script_path,
+		outfile
+	)
 end
 
 return M

--- a/lua/neotest-kotlin/src/output-parser.lua
+++ b/lua/neotest-kotlin/src/output-parser.lua
@@ -1,140 +1,110 @@
 local M = {}
 
--- the gradle prefix is this long >>> 2024-05-19T22:15:04.339-0400 [DEBUG] [TestEventLogger]
-local PREFIX_OFFSET = 54
+---Gets the result of a Gradle test output line
+---@param line string
+---@return string status passed, skipped, failed, none
+M.parse_status = function(line)
+	local result = "none"
 
--- This will get a result type ( NONE, PASSED, SKIPPED, FAILED ) from a gradle output line.
-M.get_result_type = function(line, pkg)
-  -- This will quickly skip non-TestEventLogger lines most of the time...
-  if string.sub(line, PREFIX_OFFSET, PREFIX_OFFSET) ~= "]" then
-    return nil
-  end
+	if vim.endswith(line, "PASSED") then
+		result = "passed"
+	elseif vim.endswith(line, "SKIPPED") then
+		result = "skipped"
+	elseif vim.endswith(line, "FAILED") then
+		result = "failed"
+	end
 
-  -- Test to see if the line starting after the prefix is the package name.
-  if not string.find(line, pkg, PREFIX_OFFSET + 1) then
-    return nil
-  end
-
-  if string.find(line, "PASSED", -6) then
-    return "passed"
-  end
-
-  if string.find(line, "SKIPPED", -7) then
-    return "skipped"
-  end
-
-  if string.find(line, "FAILED", -6) then
-    return "failed"
-  end
-
-  return nil
+	return result
 end
 
--- This will turn a gradle output line into an id that can be looked up by neotest
--- Example Input: '2024-05-19T22:15:04.339-0400 [DEBUG] [TestEventLogger] com.codymikol.state.neotest.NeotestKotestSpec > a namespace > com.codymikol.state.neotest.NeotestKotestSpec.should handle passed assertions PASSED'
--- Example Output: '/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt::"NeotestKotestSpec"::"a namespace"::"should handle passed assertions"'
-M.make_result_id = function(line, path)
-  --
-  -- get the line starting after the PREFIX_OFFSET
-  local line_without_prefix = string.sub(line, PREFIX_OFFSET + 2)
+-- org.example.KotestDescribeSpec > a namespace > should handle failed assertions FAILED
+-- '/home/nick/GitHub/neotest-kotlin/lua/tests/example_project/app/src/test/kotlin/org/example/KotestDescribeExample.kt::"a namespace"::"a nested namespace"::"should handle failed assertions"'
+---Parses the Neotest id from a Gradle test line output
+---@param line string
+---@param path string
+---@param package string
+---@return string? neotest_id
+M.parse_test_id = function(line, path, package)
+	if not M.is_valid_gradle_test_line(line, package) then
+		return nil
+	end
 
-  local id = path
+	local split = vim.split(line, ">", { trimempty = true })
+	-- Must have at least "fqn > test"
+	if #split < 2 then
+		return nil
+	end
 
-  local parts = vim.split(line_without_prefix, " > ", { trimempty = true })
+	local names = { unpack(split, 2) }
 
-  -- Cleaning the fully qualified class name
+	local result = path
+	for i, segment in ipairs(names) do
+		segment = vim.trim(segment)
+		if (i + 1) == #split then
+			segment = segment:match("(.+) [PASSED|FAILED|SKIPPED]")
+		end
 
-  local fullyQualifiedClassName = parts[1]
+		if vim.startswith(segment, package .. ".") then
+			segment = segment:sub(#package + 2)
+		end
 
-  local fullyQualifiedClassNameParts = vim.split(fullyQualifiedClassName, "%.")
+		result = result .. '::"' .. segment .. '"'
+	end
 
-  local className = fullyQualifiedClassNameParts[#fullyQualifiedClassNameParts]
-
-  parts[1] = className
-
-  table.remove(parts, 1)
-
-  -- cleaning the it description that is for some reason prepended with the fully qualified class name...
-
-  local itDescription = parts[#parts]
-
-  local cleanedItDescription = string.sub(itDescription, fullyQualifiedClassName:len() + 2)
-
-  parts[#parts] = cleanedItDescription
-
-  for _, value in ipairs(parts) do
-    id = id .. "::" .. '"' .. value .. '"'
-  end
-
-  -- I'm sure there is a better way to do this, but I'm sleepy...
-
-  if string.find(id, ' PASSED"', -8) then
-    return string.sub(id, 1, -9) .. '"'
-  end
-
-  if string.find(id, ' SKIPPED"', -9) then
-    return string.sub(id, 1, -10) .. '"'
-  end
-
-  if string.find(id, ' FAILED"', -8) then
-    return string.sub(id, 1, -9) .. '"'
-  end
-
-  return result
+	return result
 end
 
-local function escape_magic_chars(str)
-  return str:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1")
+---Whether the line is a valid gradle test line
+---@param line string
+---@return boolean
+function M.is_valid_gradle_test_line(line, package)
+	if not vim.startswith(line, package) then
+		return false
+	end
+
+	return M.parse_status(line) ~= "none"
 end
 
-M.get_result_short = function(line)
-  local parts = vim.split(line, ">", { trim = true })
-  local short_with_status = parts[#parts]
-  local short_with_status_parts = vim.split(short_with_status, " ")
-  table.remove(short_with_status_parts, #short_with_status_parts)
-  local short = table.concat(short_with_status_parts, " ")
-  return short:sub(2)
+---@class TestResult
+---@field id string neotest id
+---@field status string passed, skipped, failed, none
+
+---@param line string test output line
+---@param path string path to file
+---@param package string fully qualified class name
+---@return TestResult?
+M.parse_line = function(line, path, package)
+	if not M.is_valid_gradle_test_line(line, package) then
+		return nil
+	end
+
+	local id = M.parse_test_id(line, path, package)
+	if not id then
+		return nil
+	end
+
+	return {
+		id = id,
+		status = M.parse_status(line),
+	}
 end
 
----@params line string
----@params path string
-M.line_to_result = function(line, path, package)
-  if not string.find(line, "%[TestEventLogger%]") then
-    return {}
-  end
+---Converts lines of gradle output to test results
+---@param lines string[]
+---@param path string
+---@param package string
+---@return table<string, neotest.Result>
+M.parse_lines = function(lines, path, package)
+	local results = {}
 
-  if not string.find(line, escape_magic_chars(package)) then
-    return {}
-  end
+	for _, line in ipairs(lines) do
+		local result = M.parse_line(line, path, package)
+		if result ~= nil then
+			results[result.id] = result
+		end
+	end
 
-  if not string.match(line, "(PASSED)$") and not string.match(line, "(SKIPPED)$") and not string.match(line, "(FAILED)$") then
-    return {}
-  end
-
-  local id = M.make_result_id(line, path)
-  local status = M.get_result_type(line, package)
-  local short = M.get_result_short(line)
-
-  return {
-    id = id,
-    status = status,
-    short = short,
-  }
-end
-
-M.lines_to_results = function(lines, path, package)
-  local results = {}
-
-  for _, line in ipairs(lines) do
-    local result = M.line_to_result(line, path, package)
-    if not result.id then
-      -- noop
-    else
-      results[result.id] = result
-    end
-  end
-
-  return results
+	return results
 end
 
 return M

--- a/lua/neotest-kotlin/src/output-parser.lua
+++ b/lua/neotest-kotlin/src/output-parser.lua
@@ -30,7 +30,7 @@ M.parse_test_id = function(line, path, package)
 	end
 
 	local split = vim.split(line, ">", { trimempty = true })
-	-- Must have at least "fqn > test"
+	-- Must have at least "fully qualified test name > test"
 	if #split < 2 then
 		return nil
 	end
@@ -44,6 +44,10 @@ M.parse_test_id = function(line, path, package)
 			segment = segment:match("(.+) [PASSED|FAILED|SKIPPED]")
 		end
 
+		-- Deeply nested tests potentially have segments prefixed by the
+		-- fully qualified class name.
+		--
+		-- example: org.example.KotestDescribeExample.this is the test name
 		if vim.startswith(segment, package .. ".") then
 			segment = segment:sub(#package + 2)
 		end

--- a/lua/tests/command_spec.lua
+++ b/lua/tests/command_spec.lua
@@ -1,12 +1,27 @@
-describe("command", function()
-  local command = require("neotest-kotlin.src.command")
+local Path = require("plenary.path")
 
-  describe("building a gradle command", function()
-    it("should correctly build the gradle command to run a spec for a given file", function()
-      local expected =
-      "export kotest_filter_tests='An example namespace'; export kotest_filter_specs='com.codymikol.gummibear.pizza.FooClass'; ./gradlew cleanTest test --debug --console=plain | tee -a /tmp/results_example.txt"
-      result = command.parse("An example namespace", "com.codymikol.gummibear.pizza.FooClass", "/tmp/results_example.txt")
-      assert.equals(expected, result)
-    end)
-  end)
+describe("command", function()
+	local command = require("neotest-kotlin.src.command")
+	local plugin_root = Path:new("."):absolute()
+	vim.opt.rtp:append(plugin_root)
+
+	describe("building a gradle command", function()
+		it("valid", function()
+			local actual = command.parse(
+				"An example namespace",
+				"com.codymikol.gummibear.pizza.FooClass",
+				"/tmp/results_example.txt"
+			)
+
+			local init_script_path = vim.api.nvim_get_runtime_file("test-logging.init.gradle.kts", false)[1]
+
+			assert.equals(
+				string.format(
+					"kotest_filter_specs='com.codymikol.gummibear.pizza.FooClass' kotest_filter_tests='An example namespace' ./gradlew -I %s test --console=plain | tee -a /tmp/results_example.txt",
+					init_script_path
+				),
+				actual
+			)
+		end)
+	end)
 end)

--- a/lua/tests/example_project/app/src/test/kotlin/org/example/KotestDescribeExample.kt
+++ b/lua/tests/example_project/app/src/test/kotlin/org/example/KotestDescribeExample.kt
@@ -1,41 +1,34 @@
-
 package org.example
 
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 
 class KotestDescribeSpec : DescribeSpec({
-
     describe("a namespace") {
-
-       it("should handle failed assertions") {
-         "a" shouldBe "b"
-       }
-
-       it("should handle passed assertions") {
-         "a" shouldBe "a"
-       }
-
-       xit("should handle skipped assertions") {
-        "a" shouldBe "a"
-       }
-
-      describe("a nested namespace") {
-
         it("should handle failed assertions") {
-          "a" shouldBe "b"
+            "a" shouldBe "b"
         }
 
         it("should handle passed assertions") {
-          "a" shouldBe "a"
+            "a" shouldBe "a"
         }
 
         xit("should handle skipped assertions") {
-          "a" shouldBe "a"
+            "a" shouldBe "a"
         }
 
-       }
+        describe("a nested namespace") {
+            it("should handle failed assertions") {
+                "a" shouldBe "b"
+            }
 
+            it("should handle passed assertions") {
+                "a" shouldBe "a"
+            }
+
+            xit("should handle skipped assertions") {
+                "a" shouldBe "a"
+            }
+        }
     }
 })

--- a/lua/tests/example_project/gradlew
+++ b/lua/tests/example_project/gradlew
@@ -114,7 +114,7 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH="\\\"\\\""
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
 
 # Determine the Java command to use to start the JVM.
@@ -213,7 +213,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
         -classpath "$CLASSPATH" \
-        -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
+        org.gradle.wrapper.GradleWrapperMain \
         "$@"
 
 # Stop when "xargs" is not available.

--- a/lua/tests/example_project/gradlew.bat
+++ b/lua/tests/example_project/gradlew.bat
@@ -70,11 +70,11 @@ goto fail
 :execute
 @rem Setup the command line
 
-set CLASSPATH=
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/lua/tests/output-parser_spec.lua
+++ b/lua/tests/output-parser_spec.lua
@@ -1,239 +1,292 @@
--- Write a test that parses a gradle output line and tests if it is a result line.
---
-
 describe("output-parser", function()
-  local output_parser = require("neotest-kotlin.src.output-parser")
+	local output_parser = require("neotest-kotlin.src.output-parser")
 
-  local pkg_example = "com.codymikol.state.neotest.NeotestKotestSpec"
+	describe("parse_lines", function()
+		it("complete example", function()
+			output_parser.parse_lines({
+				"> Task :app:cleanTest",
+				"> Task :app:checkKotlinGradlePluginConfigurationErrors",
+				"> Task :app:compileKotlin UP-TO-DATE",
+				"> Task :app:compileJava NO-SOURCE",
+				"> Task :app:processResources NO-SOURCE",
+				"> Task :app:classes UP-TO-DATE",
+				"> Task :app:compileTestKotlin UP-TO-DATE",
+				"> Task :app:compileTestJava NO-SOURCE",
+				"> Task :app:processTestResources NO-SOURCE",
+				"> Task :app:testClasses UP-TO-DATE",
+				"> Task :app:test",
+				"org.example.KotestDescribeSpec > a namespace > should handle failed assertions FAILED",
+				'   io.kotest.assertions.AssertionFailedError: expected:<"b"> but was:<"a">',
+				"       at app//org.example.KotestDescribeSpec$1$1$1.invokeSuspend(KotestDescribeExample.kt:9)",
+				"       at app//org.example.KotestDescribeSpec$1$1$1.invoke(KotestDescribeExample.kt)",
+				"org.example.KotestDescribeSpec > a namespace > should handle passed assertions PASSED",
+				"",
+				"org.example.KotestDescribeSpec > a namespace > should handle skipped assertions SKIPPED",
+				"",
+				"org.example.KotestDescribeSpec > a namespace > a nested namespace > org.example.KotestDescribeSpec.should handle failed assertions FAILED",
+				'   io.kotest.assertions.AssertionFailedError: expected:<"b"> but was:<"a">',
+				"       at app//org.example.KotestDescribeSpec$1$1$4$1.invokeSuspend(KotestDescribeExample.kt:22)",
+				"       at app//org.example.KotestDescribeSpec$1$1$4$1.invoke(KotestDescribeExample.kt)",
+				"       at app//org.example.KotestDescribeSpec$1$1$4$1.invoke(KotestDescribeExample.kt)",
+				"       at app//io.kotest.core.spec.style.scopes.DescribeSpecContainerScope$it$3.invokeSuspend(DescribeSpecContainerScope.kt:112)",
+				"org.example.KotestDescribeSpec > a namespace > a nested namespace > org.example.KotestDescribeSpec.should handle passed assertions PASSED",
+				"org.example.KotestDescribeSpec > a namespace > a nested namespace > org.example.KotestDescribeSpec.should handle skipped assertions SKIPPED",
+				"6 tests completed, 2 failed, 2 skipped",
+				"> Task :app:test FAILED",
+				"FAILURE: Build failed with an exception.",
+				"* What went wrong:",
+				"Execution failed for task ':app:test'.",
+				"> There were failing tests. See the report at: file:///home/nick/GitHub/neotest-kotlin/lua/tests/example_project/app/build/reports/tests/test/index.html",
+				"* Try:",
+				"> Run with --scan to get full insights.",
+				"BUILD FAILED in 4s",
+				"5 actionable tasks: 3 executed, 2 up-to-date",
+			}, "/example/path", "org.example.KotestDescribeSpec")
+		end)
+	end)
 
-  local passed_example =
-  "2024-05-19T22:15:04.339-0400 [DEBUG] [TestEventLogger] com.codymikol.state.neotest.NeotestKotestSpec > a namespace > com.codymikol.state.neotest.NeotestKotestSpec.should handle passed assertions PASSED"
+	describe("parse_line", function()
+		it("invalid test line - gradle task", function()
+			local actual =
+				output_parser.parse_line("> Task :app:test", "/example/path", "org.example.KotestDescribeSpec")
 
-  local skipped_example =
-  "2024-05-19T22:15:04.339-0400 [DEBUG] [TestEventLogger] com.codymikol.state.neotest.NeotestKotestSpec > a namespace > com.codymikol.state.neotest.NeotestKotestSpec.should handle skipped assertions SKIPPED"
+			assert.is_nil(actual)
+		end)
 
-  local failed_example =
-  "2024-05-19T22:15:04.339-0400 [DEBUG] [TestEventLogger] com.codymikol.state.neotest.NeotestKotestSpec > a namespace > com.codymikol.state.neotest.NeotestKotestSpec.should handle failed assertions FAILED"
+		it("invalid test line - assertion error", function()
+			local actual = output_parser.parse_line(
+				[[io.kotest.assertions.AssertionFailedError: expected:<"b"> but was:<"a">]],
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-  describe("get_result_type", function()
-    it("should return the correct result for a non-result line", function()
-      assert.is_equal(nil, output_parser.get_result_type("This is not a result line", pkg_example))
-    end)
+			assert.is_nil(actual)
+		end)
 
-    it("should return the correct result for a PASSED result line", function()
-      assert.is_equal("passed", output_parser.get_result_type(passed_example, pkg_example))
-    end)
+		it("invalid test line - stacktrace", function()
+			local actual = output_parser.parse_line(
+				[[at app//io.kotest.engine.test.TestInvocationInterceptor$runBeforeTestAfter$executeWithBeforeAfter$1.invokeSuspend(TestInvocatio]],
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-    it("should return the correct result for a SKIPPED result line", function()
-      assert.is_equal("skipped", output_parser.get_result_type(skipped_example, pkg_example))
-    end)
+			assert.is_nil(actual)
+		end)
 
-    it("should return the correct result for a FAILED result line", function()
-      assert.is_equal("failed", output_parser.get_result_type(failed_example, pkg_example))
-    end)
-  end)
+		it("invalid test line - failure", function()
+			local actual = output_parser.parse_line(
+				[[FAILURE: Build failed with an exception.]],
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-  describe("get_result_id", function()
-    it("should transform a result string into a valid id for PASSED specs", function()
-      local result_id = output_parser.make_result_id(
-        passed_example,
-        "/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt"
-      )
-      assert.is_equal(
-        '/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt::"a namespace"::"should handle passed assertions"',
-        result_id
-      )
-    end)
-    it("should transform a result string into a valid id for FAILED specs", function()
-      local result_id = output_parser.make_result_id(
-        failed_example,
-        "/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt"
-      )
-      assert.is_equal(
-        '/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt::"a namespace"::"should handle failed assertions"',
-        result_id
-      )
-    end)
-    it("should transform a result string into a valid id for SKIPPED specs", function()
-      local result_id = output_parser.make_result_id(
-        skipped_example,
-        "/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt"
-      )
-      assert.is_equal(
-        '/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt::"a namespace"::"should handle skipped assertions"',
-        result_id
-      )
-    end)
-  end)
+			assert.is_nil(actual)
+		end)
 
-  -- We now know that YES, more than one line CAN be passed by the streaming function and is.
-  --
-  -- line{ "2024-07-08T19:48:21.734-0400 [INFO] [org.gradle.internal.nativeintegration.services.NativeServices] Initialized native services in: /home/cmikol/.gradle/native", "2024-07-08T19:48:21.753-0400 [INFO] [org.gradle.internal.nativeintegration.services.NativeServices] Initialized jansi services in: /home/cmikol/.gradle/native" }
+		it("invalid test line - build actions", function()
+			local actual = output_parser.parse_line(
+				[[5 actionable tasks: 3 executed, 2 up-to-date]],
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-  describe("line_to_result", function()
-    describe("Any message that is NOT a [TestEvent]", function()
-      local line =
-      "2024-07-08T19:48:21.734-0400 [INFO] [org.gradle.internal.nativeintegration.services.NativeServices] Initialized native services in: /home/cmikol/.gradle/native"
+			assert.is_nil(actual)
+		end)
 
-      local path = "/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt"
+		it("invalid test line - no test only fqn", function()
+			local actual = output_parser.parse_line(
+				"org.example.KotestDescribeSpec",
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-      local result = output_parser.line_to_result(line, path, pkg_example)
+			assert.is_nil(actual)
+		end)
 
-      it("should return an empty table", function()
-        assert.are.same({}, result)
-      end)
-    end)
+		it("invalid test line - assertion error", function()
+			local actual = output_parser.parse_line(
+				[[io.kotest.assertions.AssertionFaiedError: expected:<"b"> but was:<"a">]],
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-    describe("Any messages that does NOT end with PASSED, SKIPPED, or FAILED", function()
-      local line =
-      "2024-05-19T22:15:04.339-0400 [DEBUG] [TestEventLogger] "
+			assert.is_nil(actual)
+		end)
 
-      local path = "/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt"
+		it("valid - FAILED", function()
+			local actual = output_parser.parse_line(
+				"org.example.KotestDescribeSpec > should handle failed assertions FAILED",
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-      local result = output_parser.line_to_result(line, path, pkg_example)
+			assert.equal('/example/path::"should handle failed assertions"', actual.id)
+			assert.equal("failed", actual.status)
+		end)
 
-      it("should return an empty table", function()
-        assert.are.same({}, result)
-      end)
-    end)
+		it("valid - PASSED", function()
+			local actual = output_parser.parse_line(
+				"org.example.KotestDescribeSpec > should handle failed assertions PASSED",
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-    describe("Any message that is a valid TestLoggingEvent ending with PASSED", function()
-      local line =
-      "2024-05-19T22:15:04.339-0400 [DEBUG] [TestEventLogger] com.codymikol.state.neotest.NeotestKotestSpec > a namespace > com.codymikol.state.neotest.NeotestKotestSpec.should handle passed assertions PASSED"
+			assert.equal('/example/path::"should handle failed assertions"', actual.id)
+			assert.equal("passed", actual.status)
+		end)
 
-      local path = "/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt"
+		it("valid - SKIPPED", function()
+			local actual = output_parser.parse_line(
+				"org.example.KotestDescribeSpec > should handle failed assertions SKIPPED",
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-      local result_entry = output_parser.line_to_result(line, path, pkg_example)
+			assert.equal('/example/path::"should handle failed assertions"', actual.id)
+			assert.equal("skipped", actual.status)
+		end)
+	end)
 
-      local expected_id =
-      '/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt::"a namespace"::"should handle passed assertions"'
+	describe("is_valid_gradle_test_line", function()
+		it("valid", function()
+			local actual = output_parser.is_valid_gradle_test_line(
+				"org.example.KotestDescribeSpec > should handle failed assertions FAILED",
+				"org.example.KotestDescribeSpec"
+			)
 
-      it("should not be an empty table", function()
-        assert.is_not.same({}, result)
-      end)
+			assert.is_true(actual)
+		end)
 
-      it("should contain an entry with the expected id as a key", function()
-        assert.is_not.same(nil, result_entry)
-      end)
+		it("unknown package prefix", function()
+			local actual = output_parser.is_valid_gradle_test_line(
+				"org.example.Unknown > should handle failed assertions FAILED",
+				"org.example.KotestDescribeSpec"
+			)
 
-      it("should contain the correct id", function()
-        assert.is_not.same(nil, result_entry.id)
-        assert.are.same(result_entry.id, expected_id)
-      end)
+			assert.is_false(actual)
+		end)
 
-      it("should contain the correct short description", function()
-        assert.is_not.same(nil, result_entry.short)
-        assert.are.same(result_entry.short, "should handle passed assertions")
-      end)
+		it("no status", function()
+			local actual = output_parser.is_valid_gradle_test_line(
+				"org.example.KotestDescribeSpec > should handle failed assertions unknown",
+				"org.example.KotestDescribeSpec"
+			)
 
-      it("should contain the correct status", function()
-        assert.is_not.same(nil, result_entry.status)
-        assert.are.same(result_entry.status, "passed")
-      end)
-    end)
+			assert.is_false(actual)
+		end)
+	end)
 
+	describe("parse_status", function()
+		it("passed", function()
+			local actual = output_parser.parse_status("PASSED")
+			assert.equal("passed", actual)
+		end)
 
-    describe("Any message that is a valid TestLoggingEvent ending with FAILED", function()
-      local line =
-      "2024-05-19T22:15:04.339-0400 [DEBUG] [TestEventLogger] com.codymikol.state.neotest.NeotestKotestSpec > a namespace > com.codymikol.state.neotest.NeotestKotestSpec.should handle passed assertions FAILED"
+		it("failed", function()
+			local actual = output_parser.parse_status("FAILED")
+			assert.equal("failed", actual)
+		end)
 
-      local path = "/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt"
+		it("skipped", function()
+			local actual = output_parser.parse_status("SKIPPED")
+			assert.equal("skipped", actual)
+		end)
 
-      local result_entry = output_parser.line_to_result(line, path, pkg_example)
+		it("none", function()
+			local actual = output_parser.parse_status("random input")
+			assert.equal("none", actual)
+		end)
+	end)
 
-      local expected_id =
-      '/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt::"a namespace"::"should handle passed assertions"'
+	describe("parse_test_id", function()
+		it("invalid test line - gradle task", function()
+			local actual =
+				output_parser.parse_test_id("> Task :app:test", "/example/path", "org.example.KotestDescribeSpec")
 
-      it("should not be an empty table", function()
-        assert.is_not.same({}, result)
-      end)
+			assert.is_nil(actual)
+		end)
 
-      it("should contain an entry with the expected id as a key", function()
-        assert.is_not.same(nil, result_entry)
-      end)
+		it("invalid test line - assertion error", function()
+			local actual = output_parser.parse_test_id(
+				[[io.kotest.assertions.AssertionFailedError: expected:<"b"> but was:<"a">]],
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-      it("should contain the correct id", function()
-        assert.is_not.same(nil, result_entry.id)
-        assert.are.same(result_entry.id, expected_id)
-      end)
+			assert.is_nil(actual)
+		end)
 
-      it("should contain the correct short description", function()
-        assert.is_not.same(nil, result_entry.short)
-        assert.are.same(result_entry.short, "should handle passed assertions")
-      end)
+		it("invalid test line - stacktrace", function()
+			local actual = output_parser.parse_test_id(
+				[[at app//io.kotest.engine.test.TestInvocationInterceptor$runBeforeTestAfter$executeWithBeforeAfter$1.invokeSuspend(TestInvocatio]],
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-      it("should contain the correct status", function()
-        assert.is_not.same(nil, result_entry.status)
-        assert.are.same(result_entry.status, "failed")
-      end)
-    end)
+			assert.is_nil(actual)
+		end)
 
-    describe("Any message that is a valid TestLoggingEvent ending with SKIPPED", function()
-      local line =
-      "2024-05-19T22:15:04.339-0400 [DEBUG] [TestEventLogger] com.codymikol.state.neotest.NeotestKotestSpec > a namespace > com.codymikol.state.neotest.NeotestKotestSpec.should handle passed assertions SKIPPED"
+		it("invalid test line - failure", function()
+			local actual = output_parser.parse_test_id(
+				[[FAILURE: Build failed with an exception.]],
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-      local path = "/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt"
+			assert.is_nil(actual)
+		end)
 
-      local result_entry = output_parser.line_to_result(line, path, pkg_example)
+		it("invalid test line - build actions", function()
+			local actual = output_parser.parse_test_id(
+				[[5 actionable tasks: 3 executed, 2 up-to-date]],
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-      local expected_id =
-      '/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt::"a namespace"::"should handle passed assertions"'
+			assert.is_nil(actual)
+		end)
 
-      it("should not be an empty table", function()
-        assert.is_not.same({}, result)
-      end)
+		it("invalid test line - no test only fqn", function()
+			local actual = output_parser.parse_test_id(
+				"org.example.KotestDescribeSpec",
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-      it("should contain an entry with the expected id as a key", function()
-        assert.is_not.same(nil, result_entry)
-      end)
+			assert.is_nil(actual)
+		end)
 
-      it("should contain the correct id", function()
-        assert.is_not.same(nil, result_entry.id)
-        assert.are.same(result_entry.id, expected_id)
-      end)
+		it("valid top-level test", function()
+			local actual = output_parser.parse_test_id(
+				"org.example.KotestDescribeSpec > should handle failed assertions FAILED",
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-      it("should contain the correct short description", function()
-        assert.is_not.same(nil, result_entry.short)
-        assert.are.same(result_entry.short, "should handle passed assertions")
-      end)
+			assert.equal('/example/path::"should handle failed assertions"', actual)
+		end)
 
-      it("should contain the correct status", function()
-        assert.is_not.same(nil, result_entry.status)
-        assert.are.same(result_entry.status, "skipped")
-      end)
-    end)
-  end)
+		it("valid single namespace", function()
+			local actual = output_parser.parse_test_id(
+				"org.example.KotestDescribeSpec > a namespace > should handle failed assertions FAILED",
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-  describe("parse_lines", function()
-    describe("when the table contains no valid test lines", function()
-      local lines = {
-        "2024-07-09T08:46:31.200-0400 [INFO] [org.gradle.internal.nativeintegration.services.NativeServices] Initialized native services in: /home/cmikol/.gradle/native",
-        "2024-07-09T08:46:31.218-0400 [INFO] [org.gradle.internal.nativeintegration.services.NativeServices] Initialized jansi services in: /home/cmikol/.gradle/native"
-      }
+			assert.equal('/example/path::"a namespace"::"should handle failed assertions"', actual)
+		end)
 
-      local path = "/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt"
-      local result = output_parser.lines_to_results(lines, path, pkg_example)
+		it("valid multiple nested namespace", function()
+			local actual = output_parser.parse_test_id(
+				"org.example.KotestDescribeSpec > a namespace > a nested namespace > org.example.KotestDescribeSpec.should handle failed assertions FAILED",
+				"/example/path",
+				"org.example.KotestDescribeSpec"
+			)
 
-      it("should return an empty table", function()
-        assert.are.same({}, result)
-      end)
-    end)
-
-    describe("when the table contains one valid test line", function()
-      local lines = {
-        "2024-07-09T08:46:31.200-0400 [INFO] [org.gradle.internal.nativeintegration.services.NativeServices] Initialized native services in: /home/cmikol/.gradle/native",
-        "2024-07-09T08:46:31.218-0400 [INFO] [org.gradle.internal.nativeintegration.services.NativeServices] Initialized jansi services in: /home/cmikol/.gradle/native",
-        "2024-05-19T22:15:04.339-0400 [DEBUG] [TestEventLogger] com.codymikol.state.neotest.NeotestKotestSpec > a namespace > com.codymikol.state.neotest.NeotestKotestSpec.should handle passed assertions PASSED"
-      }
-
-      local path = "/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt"
-      local result = output_parser.lines_to_results(lines, path, pkg_example)
-      local expected_id =
-      '/home/cody/dev/src/git-down/src/test/kotlin/com/codymikol/state/neotest.kt::"a namespace"::"should handle passed assertions"'
-
-      it("should contain the correct result id", function()
-        assert.are.same(expected_id, result[expected_id].id)
-      end)
-    end)
-  end)
+			assert.equal(
+				'/example/path::"a namespace"::"a nested namespace"::"should handle failed assertions"',
+				actual
+			)
+		end)
+	end)
 end)

--- a/test-logging.init.gradle.kts
+++ b/test-logging.init.gradle.kts
@@ -1,0 +1,26 @@
+/**
+ * Gradle Init Script for neotest-kotlin
+ *
+ * This helps force standardized and usable output for tests
+ * so that the plugin can effectively parse the output and it's usable
+ * for users.
+ */
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
+allprojects {
+    afterEvaluate {
+        tasks.withType<Test>().configureEach {
+            /**
+             * Force re-run the tests so we have output to parse
+             * [docs](https://blog.gradle.org/stop-rerunning-tests)
+             */
+            outputs.upToDateWhen { false }
+
+            testLogging {
+                events(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+                exceptionFormat = TestExceptionFormat.FULL
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #36 

With this I think we're back in a mostly work spot! :tada: 

## Changes

- Custom gradle init script
- Proper Gradle test output parsing

```text
org.example.KotestDescribeSpec > a namespace > should handle failed assertions FAILED
```

Results in the Neotest Id of

```text
'/home/nick/GitHub/neotest-kotlin/lua/tests/example_project/app/src/test/kotlin/org/example/KotestDescribeExample.kt::"a namespace"::"a nested namespace"::"should handle failed assertions"'
```

Where /home/nick/GitHub/neotest-kotlin is my path to the plugin :smile:

![2025-06-24_19-35](https://github.com/user-attachments/assets/da6c4118-7198-45f6-b5d6-f4bcf2fc4649)

:tada: :tada: :tada: 

## Future Changes

- KoTest run an individual test

I've been digging into this, but it's way harder than I would've thought? Trying to steal as much as I can from KoTest IntelliJ Plugin, but they actually run a custom plugin/app to run individual tests and don't actually use the environment variables? This may require a lot more digging to get this to work properly.