### PR TITLE
feat: Setup Kotest FreeSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This is currently in development, here is a roadmap of planned support for this 
 - [x] Kotest - FunSpec
 - [ ] Kotest - AnnotationSpec
 - [ ] Kotest - BehaviorSpec
-- [ ] Kotest - FreeSpec
+- [x] Kotest - FreeSpec
 - [x] Kotest - StringSpec
 - [ ] Kotest - WordSpec
 - [x] Kotest - ShouldSpec

--- a/lua/neotest-kotlin/treesitter/kotest-query.lua
+++ b/lua/neotest-kotlin/treesitter/kotest-query.lua
@@ -90,7 +90,24 @@ return [[
 ) @test.definition
 
 ;; -- todo BEHAVIOR SPEC --
-;; -- todo FREE SPEC --
+;; --- FREE SPEC ---
+
+; Matches "context" - { /** body **/ }
+
+(additive_expression
+  (string_literal) @namespace.name
+  (lambda_literal)
+) @namespace.definition
+
+; Matches "test" { /** body **/ }
+
+(call_expression
+  (string_literal) @test.name
+    (call_suffix
+      (annotated_lambda)
+  )
+) @test.definition
+
 ;; -- todo WORD SPEC --
 ;; -- todo FEATURE SPEC --
 ;; -- todo EXPECT SPEC --

--- a/tests/example_project/app/src/test/kotlin/org/example/KotestFreeSpec.kt
+++ b/tests/example_project/app/src/test/kotlin/org/example/KotestFreeSpec.kt
@@ -1,0 +1,25 @@
+package org.example
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class KotestFreeSpec : FreeSpec({
+    "namespace" - {
+        "pass" {
+            1 shouldBe 1
+        }
+
+        "fail" {
+            1 shouldBe 2
+        }
+
+        "nested namespace" - {
+            "pass" {
+                1 shouldBe 1
+            }
+
+            "fail" {
+                1 shouldBe 2
+            }
+        }
+    }
+})

--- a/tests/treesitter/treesitter_spec.lua
+++ b/tests/treesitter/treesitter_spec.lua
@@ -18,6 +18,7 @@ describe("treesitter", function()
 	local shouldspec_file = vim.fs.joinpath(example_project_path, "KotestShouldSpec.kt")
 	local describespec_file = vim.fs.joinpath(example_project_path, "KotestDescribeSpec.kt")
 	local stringspec_file = vim.fs.joinpath(example_project_path, "KotestStringSpec.kt")
+	local freespec_file = vim.fs.joinpath(example_project_path, "KotestFreeSpec.kt")
 
 	describe("java_package", function()
 		nio.tests.it("valid", function()
@@ -49,6 +50,44 @@ describe("treesitter", function()
 			assert.is_not_nil(test2)
 			assert.equals("test", test2.type)
 			assert.equals('"fail"', test2.name)
+		end)
+
+		nio.tests.it("FreeSpec", function()
+			local tree = treesitter.parse_positions(freespec_file):to_list()
+			assert.equals("KotestFreeSpec.kt", tree[1].name)
+			assert.equals("file", tree[1].type)
+
+			local content = tree[2]
+
+			local namespace = content[1]
+			assert.is_not_nil(namespace)
+			assert.equals('"namespace"', namespace.name)
+			assert.equals("namespace", namespace.type)
+
+			local test = content[2][1]
+			assert.is_not_nil(test)
+			assert.equals("test", test.type)
+			assert.equals('"pass"', test.name)
+
+			local test2 = content[3][1]
+			assert.is_not_nil(test2)
+			assert.equals("test", test2.type)
+			assert.equals('"fail"', test2.name)
+
+			local namespace2 = content[4][1]
+			assert.is_not_nil(namespace2)
+			assert.equals("namespace", namespace2.type)
+			assert.equals('"nested namespace"', namespace2.name)
+
+			local test3 = content[4][2][1]
+			assert.is_not_nil(test3)
+			assert.equals("test", test3.type)
+			assert.equals('"pass"', test3.name)
+
+			local test4 = content[4][3][1]
+			assert.is_not_nil(test4)
+			assert.equals("test", test4.type)
+			assert.equals('"fail"', test4.name)
 		end)
 
 		nio.tests.it("FunSpec", function()


### PR DESCRIPTION
Closes #10 

This is based on #40 because that adds testing for the spec parsing so we can ensure that things actually work! :tada:

I'll rebase once #40 is merged so this PR is clean. (This PR actually starts at https://github.com/codymikol/neotest-kotlin/pull/44/commits/30b2481afc1980a02c627e2c9a047891761c70b0)