### PR TITLE
feat: Setup Kotest AnnotationSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is currently in development, here is a roadmap of planned support for this 
 
 - [x] Kotest - DescribeSpec
 - [x] Kotest - FunSpec
-- [ ] Kotest - AnnotationSpec
+- [x] Kotest - AnnotationSpec
 - [ ] Kotest - BehaviorSpec
 - [x] Kotest - FreeSpec
 - [x] Kotest - StringSpec

--- a/lua/neotest-kotlin/output_parser.lua
+++ b/lua/neotest-kotlin/output_parser.lua
@@ -55,7 +55,7 @@ function M.parse_test_id(line, class_to_path)
 			segment = segment:sub(#fully_qualified_class + 2)
 		end
 
-		result = result .. '::"' .. segment .. '"'
+		result = result .. "::" .. segment
 	end
 
 	return result

--- a/lua/neotest-kotlin/treesitter/kotest-query.lua
+++ b/lua/neotest-kotlin/treesitter/kotest-query.lua
@@ -12,7 +12,9 @@ return [[
     (call_suffix 
       (value_arguments 
         (value_argument 
-          (string_literal) @namespace.name
+          (string_literal
+            (string_content) @namespace.name
+          ) 
         )
       ) (annotated_lambda)
     )
@@ -25,7 +27,9 @@ return [[
     (call_suffix 
       (value_arguments 
         (value_argument 
-          (string_literal) @test.name 
+          (string_literal
+            (string_content) @test.name
+          )
         )
       ) (annotated_lambda)
     ) 
@@ -44,7 +48,9 @@ return [[
     (call_suffix 
       (value_arguments 
         (value_argument 
-          (string_literal) @namespace.name
+          (string_literal
+            (string_content) @namespace.name
+          )
         )
       ) (annotated_lambda)
     )
@@ -57,7 +63,9 @@ return [[
     (call_suffix 
       (value_arguments 
         (value_argument 
-          (string_literal) @test.name 
+          (string_literal
+            (string_content) @test.name
+          ) 
         )
       ) (annotated_lambda)
     ) 
@@ -72,7 +80,9 @@ return [[
     (call_suffix 
       (value_arguments 
         (value_argument 
-          (string_literal) @test.name 
+          (string_literal
+            (string_content) @test.name
+          )
         )
       ) (annotated_lambda)
     ) 
@@ -83,9 +93,11 @@ return [[
 ; Matches "test" { /** body **/ }
 
 (call_expression
-  (string_literal) @test.name
-    (call_suffix
-      (annotated_lambda)
+  (string_literal
+    (string_content) @test.name
+  ) 
+  (call_suffix
+    (annotated_lambda)
   )
 ) @test.definition
 
@@ -95,21 +107,24 @@ return [[
 ; Matches "context" - { /** body **/ }
 
 (additive_expression
-  (string_literal) @namespace.name
+  (string_literal
+    (string_content) @namespace.name
+  )
   (lambda_literal)
 ) @namespace.definition
 
 ; Matches "test" { /** body **/ }
 
 (call_expression
-  (string_literal) @test.name
-    (call_suffix
-      (annotated_lambda)
+  (string_literal 
+    (string_content) @test.name
+  )
+  (call_suffix
+    (annotated_lambda)
   )
 ) @test.definition
 
 ;; -- todo WORD SPEC --
-;; -- todo FEATURE SPEC --
 ;; --- FEATURE SPEC ---
 
 ; Matches namespace feature("context") { /** body **/ }
@@ -119,7 +134,9 @@ return [[
     (call_suffix 
       (value_arguments 
         (value_argument 
-          (string_literal) @namespace.name
+          (string_literal
+            (string_content) @namespace.name
+          ) 
         )
       ) (annotated_lambda)
     )
@@ -132,7 +149,9 @@ return [[
     (call_suffix 
       (value_arguments 
         (value_argument 
-          (string_literal) @test.name 
+          (string_literal
+            (string_content) @test.name
+          )
         )
       ) (annotated_lambda)
     ) 
@@ -147,12 +166,30 @@ return [[
     (call_suffix 
       (value_arguments 
         (value_argument 
-          (string_literal) @test.name 
+          (string_literal
+            (string_content) @test.name
+          )
         )
       ) (annotated_lambda)
     ) 
 ) @test.definition
 
-;; -- todo ANNOTATION SPEC --
+;; --- ANNOTATION SPEC ---
+
+; Matches @Test fun Test() { /** body **/ }
+; Doesn't Match @Ignore annotated functions
+
+(function_declaration
+  (modifiers
+    (annotation
+      (user_type
+        (type_identifier) @annotation_name
+      )
+    )+ @annotations (#vim-match? @annotations "\%(\Ignore\)\@<!Test")
+  )
+  (simple_identifier) @test.name
+  (function_value_parameters)
+  (function_body)
+) @test.definition
 
 ]]

--- a/tests/example_project/app/src/test/kotlin/org/example/KotestAnnotationSpec.kt
+++ b/tests/example_project/app/src/test/kotlin/org/example/KotestAnnotationSpec.kt
@@ -1,0 +1,22 @@
+package org.example
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+
+class KotestAnnotationSpec : AnnotationSpec() {
+    @Test
+    fun pass() {
+        1 shouldBe 1
+    }
+
+    @Test
+    fun fail() {
+        1 shouldBe 2
+    }
+
+    @Test
+    @Ignore
+    fun ignore() {
+        1 shouldBe 5
+    }
+}

--- a/tests/output_parser_spec.lua
+++ b/tests/output_parser_spec.lua
@@ -153,7 +153,7 @@ describe("output_parser", function()
 			)
 
 			assert.equal(
-				'/home/user/project/org/example/KotestDescribeSpec.kt::"should handle failed assertions"',
+				"/home/user/project/org/example/KotestDescribeSpec.kt::should handle failed assertions",
 				actual.id
 			)
 			assert.equal("failed", actual.status)
@@ -166,7 +166,7 @@ describe("output_parser", function()
 			)
 
 			assert.equal(
-				'/home/user/project/org/example/KotestDescribeSpec.kt::"should handle failed assertions"',
+				"/home/user/project/org/example/KotestDescribeSpec.kt::should handle failed assertions",
 				actual.id
 			)
 			assert.equal("passed", actual.status)
@@ -179,7 +179,7 @@ describe("output_parser", function()
 			)
 
 			assert.equal(
-				'/home/user/project/org/example/KotestDescribeSpec.kt::"should handle failed assertions"',
+				"/home/user/project/org/example/KotestDescribeSpec.kt::should handle failed assertions",
 				actual.id
 			)
 			assert.equal("skipped", actual.status)
@@ -287,7 +287,7 @@ describe("output_parser", function()
 			)
 
 			assert.equal(
-				'/home/user/project/org/example/KotestDescribeSpec.kt::"should handle failed assertions"',
+				"/home/user/project/org/example/KotestDescribeSpec.kt::should handle failed assertions",
 				actual
 			)
 		end)
@@ -299,7 +299,7 @@ describe("output_parser", function()
 			)
 
 			assert.equal(
-				'/home/user/project/org/example/KotestDescribeSpec.kt::"a namespace"::"should handle failed assertions"',
+				"/home/user/project/org/example/KotestDescribeSpec.kt::a namespace::should handle failed assertions",
 				actual
 			)
 		end)
@@ -311,7 +311,7 @@ describe("output_parser", function()
 			)
 
 			assert.equal(
-				'/home/user/project/org/example/KotestDescribeSpec.kt::"a namespace"::"a nested namespace"::"should handle failed assertions"',
+				"/home/user/project/org/example/KotestDescribeSpec.kt::a namespace::a nested namespace::should handle failed assertions",
 				actual
 			)
 		end)

--- a/tests/treesitter/treesitter_spec.lua
+++ b/tests/treesitter/treesitter_spec.lua
@@ -21,6 +21,7 @@ describe("treesitter", function()
 	local expectspec_file = vim.fs.joinpath(example_project_path, "KotestExpectSpec.kt")
 	local freespec_file = vim.fs.joinpath(example_project_path, "KotestFreeSpec.kt")
 	local featurespec_file = vim.fs.joinpath(example_project_path, "KotestFeatureSpec.kt")
+	local annotationspec_file = vim.fs.joinpath(example_project_path, "KotestAnnotationSpec.kt")
 
 	describe("java_package", function()
 		nio.tests.it("valid", function()
@@ -46,12 +47,28 @@ describe("treesitter", function()
 			local test = tree[2][1]
 			assert.is_not_nil(test)
 			assert.equals("test", test.type)
-			assert.equals('"pass"', test.name)
+			assert.equals("pass", test.name)
 
 			local test2 = tree[3][1]
 			assert.is_not_nil(test2)
 			assert.equals("test", test2.type)
-			assert.equals('"fail"', test2.name)
+			assert.equals("fail", test2.name)
+		end)
+
+		nio.tests.it("AnnotationSpec", function()
+			local tree = treesitter.parse_positions(annotationspec_file):to_list()
+			assert.equals("KotestAnnotationSpec.kt", tree[1].name)
+			assert.equals("file", tree[1].type)
+
+			local test = tree[2][1]
+			assert.is_not_nil(test)
+			assert.equals("test", test.type)
+			assert.equals("pass", test.name)
+
+			local test2 = tree[3][1]
+			assert.is_not_nil(test2)
+			assert.equals("test", test2.type)
+			assert.equals("fail", test2.name)
 		end)
 
 		nio.tests.it("ExpectSpec", function()
@@ -63,33 +80,33 @@ describe("treesitter", function()
 
 			local namespace = content[1]
 			assert.is_not_nil(namespace)
-			assert.equals('"namespace"', namespace.name)
+			assert.equals("namespace", namespace.name)
 			assert.equals("namespace", namespace.type)
 
 			local test = content[2][1]
 			assert.is_not_nil(test)
 			assert.equals("test", test.type)
-			assert.equals('"pass"', test.name)
+			assert.equals("pass", test.name)
 
 			local test2 = content[3][1]
 			assert.is_not_nil(test2)
 			assert.equals("test", test2.type)
-			assert.equals('"fail"', test2.name)
+			assert.equals("fail", test2.name)
 
 			local namespace2 = content[4][1]
 			assert.is_not_nil(namespace2)
 			assert.equals("namespace", namespace2.type)
-			assert.equals('"nested namespace"', namespace2.name)
+			assert.equals("nested namespace", namespace2.name)
 
 			local test3 = content[4][2][1]
 			assert.is_not_nil(test3)
 			assert.equals("test", test3.type)
-			assert.equals('"pass"', test3.name)
+			assert.equals("pass", test3.name)
 
 			local test4 = content[4][3][1]
 			assert.is_not_nil(test4)
 			assert.equals("test", test4.type)
-			assert.equals('"fail"', test4.name)
+			assert.equals("fail", test4.name)
 		end)
 
 		nio.tests.it("FreeSpec", function()
@@ -101,33 +118,33 @@ describe("treesitter", function()
 
 			local namespace = content[1]
 			assert.is_not_nil(namespace)
-			assert.equals('"namespace"', namespace.name)
+			assert.equals("namespace", namespace.name)
 			assert.equals("namespace", namespace.type)
 
 			local test = content[2][1]
 			assert.is_not_nil(test)
 			assert.equals("test", test.type)
-			assert.equals('"pass"', test.name)
+			assert.equals("pass", test.name)
 
 			local test2 = content[3][1]
 			assert.is_not_nil(test2)
 			assert.equals("test", test2.type)
-			assert.equals('"fail"', test2.name)
+			assert.equals("fail", test2.name)
 
 			local namespace2 = content[4][1]
 			assert.is_not_nil(namespace2)
 			assert.equals("namespace", namespace2.type)
-			assert.equals('"nested namespace"', namespace2.name)
+			assert.equals("nested namespace", namespace2.name)
 
 			local test3 = content[4][2][1]
 			assert.is_not_nil(test3)
 			assert.equals("test", test3.type)
-			assert.equals('"pass"', test3.name)
+			assert.equals("pass", test3.name)
 
 			local test4 = content[4][3][1]
 			assert.is_not_nil(test4)
 			assert.equals("test", test4.type)
-			assert.equals('"fail"', test4.name)
+			assert.equals("fail", test4.name)
 		end)
 
 		nio.tests.it("FeatureSpec", function()
@@ -139,33 +156,33 @@ describe("treesitter", function()
 
 			local namespace = content[1]
 			assert.is_not_nil(namespace)
-			assert.equals('"namespace"', namespace.name)
+			assert.equals("namespace", namespace.name)
 			assert.equals("namespace", namespace.type)
 
 			local test = content[2][1]
 			assert.is_not_nil(test)
 			assert.equals("test", test.type)
-			assert.equals('"pass"', test.name)
+			assert.equals("pass", test.name)
 
 			local test2 = content[3][1]
 			assert.is_not_nil(test2)
 			assert.equals("test", test2.type)
-			assert.equals('"fail"', test2.name)
+			assert.equals("fail", test2.name)
 
 			local namespace2 = content[4][1]
 			assert.is_not_nil(namespace2)
 			assert.equals("namespace", namespace2.type)
-			assert.equals('"nested namespace"', namespace2.name)
+			assert.equals("nested namespace", namespace2.name)
 
 			local test3 = content[4][2][1]
 			assert.is_not_nil(test3)
 			assert.equals("test", test3.type)
-			assert.equals('"pass"', test3.name)
+			assert.equals("pass", test3.name)
 
 			local test4 = content[4][3][1]
 			assert.is_not_nil(test4)
 			assert.equals("test", test4.type)
-			assert.equals('"fail"', test4.name)
+			assert.equals("fail", test4.name)
 		end)
 
 		nio.tests.it("FunSpec", function()
@@ -177,33 +194,33 @@ describe("treesitter", function()
 
 			local namespace = content[1]
 			assert.is_not_nil(namespace)
-			assert.equals('"namespace"', namespace.name)
+			assert.equals("namespace", namespace.name)
 			assert.equals("namespace", namespace.type)
 
 			local test = content[2][1]
 			assert.is_not_nil(test)
 			assert.equals("test", test.type)
-			assert.equals('"pass"', test.name)
+			assert.equals("pass", test.name)
 
 			local test2 = content[3][1]
 			assert.is_not_nil(test2)
 			assert.equals("test", test2.type)
-			assert.equals('"fail"', test2.name)
+			assert.equals("fail", test2.name)
 
 			local namespace2 = content[4][1]
 			assert.is_not_nil(namespace2)
 			assert.equals("namespace", namespace2.type)
-			assert.equals('"nested namespace"', namespace2.name)
+			assert.equals("nested namespace", namespace2.name)
 
 			local test3 = content[4][2][1]
 			assert.is_not_nil(test3)
 			assert.equals("test", test3.type)
-			assert.equals('"pass"', test3.name)
+			assert.equals("pass", test3.name)
 
 			local test4 = content[4][3][1]
 			assert.is_not_nil(test4)
 			assert.equals("test", test4.type)
-			assert.equals('"fail"', test4.name)
+			assert.equals("fail", test4.name)
 		end)
 
 		nio.tests.it("ShouldSpec", function()
@@ -215,33 +232,33 @@ describe("treesitter", function()
 
 			local namespace = content[1]
 			assert.is_not_nil(namespace)
-			assert.equals('"namespace"', namespace.name)
+			assert.equals("namespace", namespace.name)
 			assert.equals("namespace", namespace.type)
 
 			local test = content[2][1]
 			assert.is_not_nil(test)
 			assert.equals("test", test.type)
-			assert.equals('"pass"', test.name)
+			assert.equals("pass", test.name)
 
 			local test2 = content[3][1]
 			assert.is_not_nil(test2)
 			assert.equals("test", test2.type)
-			assert.equals('"fail"', test2.name)
+			assert.equals("fail", test2.name)
 
 			local namespace2 = content[4][1]
 			assert.is_not_nil(namespace2)
 			assert.equals("namespace", namespace2.type)
-			assert.equals('"nested namespace"', namespace2.name)
+			assert.equals("nested namespace", namespace2.name)
 
 			local test3 = content[4][2][1]
 			assert.is_not_nil(test3)
 			assert.equals("test", test3.type)
-			assert.equals('"pass"', test3.name)
+			assert.equals("pass", test3.name)
 
 			local test4 = content[4][3][1]
 			assert.is_not_nil(test4)
 			assert.equals("test", test4.type)
-			assert.equals('"fail"', test4.name)
+			assert.equals("fail", test4.name)
 		end)
 
 		nio.tests.it("DescribeSpec", function()
@@ -256,32 +273,32 @@ describe("treesitter", function()
 			local namespace = content[1]
 			assert.is_not_nil(namespace)
 			assert.equals("namespace", namespace.type)
-			assert.equals('"a namespace"', namespace.name)
+			assert.equals("a namespace", namespace.name)
 
 			local test = content[2][1]
 			assert.is_not_nil(test)
 			assert.equals("test", test.type)
-			assert.equals('"should handle failed assertions"', test.name)
+			assert.equals("should handle failed assertions", test.name)
 
 			local test2 = content[3][1]
 			assert.is_not_nil(test2)
 			assert.equals("test", test2.type)
-			assert.equals('"should handle passed assertions"', test2.name)
+			assert.equals("should handle passed assertions", test2.name)
 
 			local namespace2 = content[4][1]
 			assert.is_not_nil(namespace2)
 			assert.equals("namespace", namespace2.type)
-			assert.equals('"a nested namespace"', namespace2.name)
+			assert.equals("a nested namespace", namespace2.name)
 
 			local test3 = content[4][2][1]
 			assert.is_not_nil(test3)
 			assert.equals("test", test3.type)
-			assert.equals('"should handle failed assertions"', test3.name)
+			assert.equals("should handle failed assertions", test3.name)
 
 			local test4 = content[4][3][1]
 			assert.is_not_nil(test4)
 			assert.equals("test", test4.type)
-			assert.equals('"should handle passed assertions"', test4.name)
+			assert.equals("should handle passed assertions", test4.name)
 		end)
 	end)
 end)


### PR DESCRIPTION
Closes #14 

While implementing this I tried to cover the cases for JUnit and kotlin-test, but hit blockers with them mainly around them appending `()` to every single test. 

This PR overall has a very large change, no longer using `string_literal` as the `@test.name` in the treesitter queries. Now using `string_content`, this is required for AnnotationSpec since it's the **only** Kotest spec that uses function names rather than Strings to denote test names.

This results in the tests being listed in Neotest summary they're no longer wrapped in Strings! :tada: 

Which I see as a general readability improvement and a positive

![Screenshot_20250629_023657-1](https://github.com/user-attachments/assets/0953f5fe-4222-415f-a2c7-064064bd1e5e)

**NOTE**: This PR contains a "bug", which should also be solved by https://github.com/nvim-neotest/neotest/issues/516, here's the case that's problematic!

```kotlin
class Example : AnnotationSpec() {
  @Test
  fun `this is a test name with spaces in it`() {
    1 shouldBe 1
  }
}
```

This fails because the `string_content` we get from Treesitter includes the backticks and thereby our parser uses the wrong Neotest ID. Here again, we can use the `#gsub!` directive to remove the backticks as they're not really part of the name anyway (just an escape so that you can include invalid function_name characters in a function name) and we're good to go. I'll open an issue that documents this and my proposed solution once this is merged :+1: 

There's no current solution for AnnotationSpec to bypass this issue, there doesn't exist a `@DisplayName` annotation like what is used by JUnit (which is another edge case btw in JUnit)