### PR TITLE
feat: Support errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This is currently in development, here is a roadmap of planned support for this 
 - [x] Display available test results
 - [x] Run tests
 - [x] Report result status
-- [ ] Report failure output
+- [x] Report failure output
 
 ### Contributing
 

--- a/lua/neotest-kotlin/init.lua
+++ b/lua/neotest-kotlin/init.lua
@@ -115,6 +115,10 @@ function M.Adapter.build_spec(args)
 	return run_spec
 end
 
+---@class neotest.Error
+---@field message string
+---@field line? integer
+
 ---@class neotest.Result
 ---@field status neotest.ResultStatus
 ---@field output? string Path to file containing full output data

--- a/lua/neotest-kotlin/output_parser.lua
+++ b/lua/neotest-kotlin/output_parser.lua
@@ -137,6 +137,7 @@ function M.determine_all_classes(path)
 	return results
 end
 
+---Parses test output for Kotest
 ---@param output string[] all lines of output associated with this test failure
 ---@param class_to_path table<string, string> fully qualified class name to path
 ---@return string?, neotest.Error[]


### PR DESCRIPTION
Closes #3 

Some weirdness with Neotest here, but you can now view individual tests output. Including passing tests.

![Screenshot_20250701_221829](https://github.com/user-attachments/assets/c4221504-30df-4e49-969b-fc838cd00836)
![Screenshot_20250701_221900](https://github.com/user-attachments/assets/657dad94-5eee-4599-91aa-eff60003e87b)

Weirdness in this latter screenshot, where Neotest doesn't always expand to the length of the text so it clips it? For some reason you can't even `$` to get to the end of the line to view it either.