### PR TITLE
feat: support Kotest WordSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is currently in development, here is a roadmap of planned support for this 
 - [ ] Kotest - BehaviorSpec
 - [x] Kotest - FreeSpec
 - [x] Kotest - StringSpec
-- [ ] Kotest - WordSpec
+- [x] Kotest - WordSpec
 - [x] Kotest - ShouldSpec
 - [x] Kotest - ExpectSpec
 - [x] Kotest - FeatureSpec

--- a/lua/neotest-kotlin/treesitter/init.lua
+++ b/lua/neotest-kotlin/treesitter/init.lua
@@ -6,6 +6,24 @@ local package_query = require("neotest-kotlin.treesitter.package-query")
 
 local M = {}
 
+---@enum neotest.PositionType
+M.PositionType = {
+  dir = "dir",
+  file = "file",
+  namespace = "namespace",
+  test = "test",
+}
+
+---@class neotest.Position
+---@field id string
+---@field type neotest.PositionType
+---@field name string
+---@field path string
+---@field range integer[]
+
+---@class Position : neotest.Position
+---@field custom_id string a custom id that differs from the name
+
 ---Get all matches for the query perform on the path
 ---@param path string
 ---@param query string
@@ -62,6 +80,62 @@ function M.java_package(file)
   return get_all_matches_as_string(file, package_query)[1]
 end
 
+---Creates a neotest id of the form 'path::namespace::test' using the Position.custom_id if it exists otherwise name.
+---@param position Position
+---@param parents Position[]
+---@return string
+local function position_id(position, parents)
+  return table.concat(
+    vim
+      .iter({
+        position.path,
+        ---@param pos Position
+        vim.tbl_map(function(pos)
+          return pos.custom_id or pos.name
+        end, parents),
+        position.custom_id or position.name,
+      })
+      :flatten(math.huge)
+      :totable(),
+    "::"
+  )
+end
+
+---builds a neotest.Position from a treesitter query
+---@param file_path string
+---@param source string
+---@param captured_nodes table<string, userdata>
+---@param metadata table<string, vim.treesitter.query.TSMetadata>
+---@return Position
+local function build_position(file_path, source, captured_nodes, metadata)
+  ---@param captured_nodes table<string, userdata>
+  local function get_match_type(captured_nodes)
+    if captured_nodes["test.name"] then
+      return "test"
+    end
+    if captured_nodes["namespace.name"] then
+      return "namespace"
+    end
+  end
+
+  local match_type = get_match_type(captured_nodes)
+  if match_type then
+    local node_name = match_type .. ".name"
+    ---@type string
+    local name = vim.treesitter.get_node_text(captured_nodes[node_name], source)
+
+    local definition = captured_nodes[match_type .. ".definition"]
+
+    return {
+      type = match_type,
+      path = file_path,
+      name = name,
+      custom_id = metadata[node_name] and metadata[node_name].text,
+      range = { definition:range() },
+    }
+  end
+end
+
 ---Uses neotest.treeistter.parse_positions to discover all namespaces/tests in a file.
 ---@param file string
 ---@return neotest.Tree?
@@ -69,39 +143,8 @@ function M.parse_positions(file)
   return neotest.treesitter.parse_positions(file, kotest_query, {
     nested_namespaces = true,
     nested_tests = false,
-    ---@type fun(file_path: string, source: string, captured_nodes: table<string, userdata>, metadata: table<string, vim.treesitter.query.TSMetadata>): neotest.Position|neotest.Position[]|nil Builds one or more positions from the captured nodes from a query match.
-    build_position = function(file_path, source, captured_nodes, metadata)
-      ---@param captured_nodes table<string, userdata>
-      local function get_match_type(captured_nodes)
-        if captured_nodes["test.name"] then
-          return "test"
-        end
-        if captured_nodes["namespace.name"] then
-          return "namespace"
-        end
-      end
-
-      local match_type = get_match_type(captured_nodes)
-      if match_type then
-        local node_name = match_type .. ".name"
-        ---@type string
-        local name =
-          vim.treesitter.get_node_text(captured_nodes[node_name], source)
-
-        if metadata[node_name] ~= nil and metadata[node_name].text ~= nil then
-          name = metadata[node_name].text
-        end
-
-        local definition = captured_nodes[match_type .. ".definition"]
-
-        return {
-          type = match_type,
-          path = file_path,
-          name = name,
-          range = { definition:range() },
-        }
-      end
-    end,
+    build_position = build_position,
+    position_id = position_id,
   })
 end
 

--- a/lua/neotest-kotlin/treesitter/kotest-query.lua
+++ b/lua/neotest-kotlin/treesitter/kotest-query.lua
@@ -124,7 +124,40 @@ return [[
   )
 ) @test.definition
 
-;; -- todo WORD SPEC --
+;; --- WORD SPEC ---
+
+; Matches "context" `when` { /** body **/ }
+; Matches "context" When { /** body **/ }
+
+(infix_expression
+  (string_literal
+    (string_content) @namespace.name (#gsub! @namespace.name "$" " when")
+  )
+  (simple_identifier) @function_name (#any-of? @function_name "`when`" "When")
+  (lambda_literal)
+) @namespace.definition
+
+; Matches "context" should { /** body **/ }
+
+(infix_expression
+  (string_literal
+    (string_content) @namespace.name (#gsub! @namespace.name "$" " should")
+  )
+  (simple_identifier) @function_name (#eq? @function_name "should")
+  (lambda_literal)
+) @namespace.definition
+
+; Matches "test" { /** body **/ }
+
+(call_expression
+  (string_literal
+    (string_content) @test.name
+  )
+    (call_suffix
+      (annotated_lambda)
+  )
+) @test.definition
+
 ;; --- FEATURE SPEC ---
 
 ; Matches namespace feature("context") { /** body **/ }

--- a/tests/example_project/app/src/test/kotlin/org/example/KotestWordSpec.kt
+++ b/tests/example_project/app/src/test/kotlin/org/example/KotestWordSpec.kt
@@ -1,0 +1,41 @@
+package org.example
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+class KotestWordSpec :
+    WordSpec({
+        "When namespace" When {
+            "nested When namespace" should {
+                "pass" {
+                    1 shouldBe 1
+                }
+
+                "fail" {
+                    1 shouldBe 2
+                }
+            }
+        }
+
+        "`when` namespace" `when` {
+            "nested `when` namespace" should {
+                "pass" {
+                    1 shouldBe 1
+                }
+
+                "fail" {
+                    1 shouldBe 2
+                }
+            }
+        }
+
+        "namespace" should {
+            "pass" {
+                1 shouldBe 1
+            }
+
+            "fail" {
+                1 shouldBe 2
+            }
+        }
+    })

--- a/tests/output_parser_functional_spec.lua
+++ b/tests/output_parser_functional_spec.lua
@@ -29,6 +29,7 @@ describe("output_parser functional", function()
   local featurespec_file = vim.fs.joinpath(tests_path, "KotestFeatureSpec.kt")
   local annotationspec_file =
     vim.fs.joinpath(tests_path, "KotestAnnotationSpec.kt")
+  local wordspec_file = vim.fs.joinpath(tests_path, "KotestWordSpec.kt")
 
   nio.tests.it("functional test", function()
     ---@type string
@@ -56,7 +57,37 @@ describe("output_parser functional", function()
 
     local results = neotest_kotlin.results(spec, {}, {})
     local ids = vim.tbl_keys(results)
-    assert.equals(31, #ids)
+    assert.equals(37, #ids)
+
+    -- KotestWordSpec.kt
+    assert.equals(6, #vim.tbl_filter(function(value)
+      return vim.startswith(value, wordspec_file)
+    end, ids))
+
+    assert.equals(
+      "passed",
+      results[wordspec_file .. "::When namespace when::nested When namespace should::pass"].status
+    )
+    assert.equals(
+      "failed",
+      results[wordspec_file .. "::When namespace when::nested When namespace should::fail"].status
+    )
+    assert.equals(
+      "passed",
+      results[wordspec_file .. "::`when` namespace when::nested `when` namespace should::pass"].status
+    )
+    assert.equals(
+      "failed",
+      results[wordspec_file .. "::`when` namespace when::nested `when` namespace should::fail"].status
+    )
+    assert.equals(
+      "passed",
+      results[wordspec_file .. "::namespace should::pass"].status
+    )
+    assert.equals(
+      "failed",
+      results[wordspec_file .. "::namespace should::fail"].status
+    )
 
     -- KotestDescribeSpec.kt
     assert.equals(6, #vim.tbl_filter(function(value)

--- a/tests/treesitter/treesitter_spec.lua
+++ b/tests/treesitter/treesitter_spec.lua
@@ -55,13 +55,18 @@ describe("treesitter", function()
 
       local When_namespace = tree[2][1]
       assert.is_not_nil(When_namespace)
+      assert.equals(wordspec_file .. "::When namespace when", When_namespace.id)
       assert.equals("namespace", When_namespace.type)
-      assert.equals("When namespace when", When_namespace.name)
+      assert.equals("When namespace", When_namespace.name)
 
       local When_nested_namespace = tree[2][2][1]
       assert.is_not_nil(When_nested_namespace)
+      assert.equals(
+        wordspec_file .. "::When namespace when::nested When namespace should",
+        When_nested_namespace.id
+      )
       assert.equals("namespace", When_nested_namespace.type)
-      assert.equals("nested When namespace should", When_nested_namespace.name)
+      assert.equals("nested When namespace", When_nested_namespace.name)
 
       local When_nested_namespace_pass_test = tree[2][2][2][1]
       assert.is_not_nil(When_nested_namespace_pass_test)
@@ -75,16 +80,22 @@ describe("treesitter", function()
 
       local when_namespace = tree[3][1]
       assert.is_not_nil(when_namespace)
+      assert.equals(
+        wordspec_file .. "::`when` namespace when",
+        when_namespace.id
+      )
       assert.equals("namespace", when_namespace.type)
-      assert.equals("`when` namespace when", when_namespace.name)
+      assert.equals("`when` namespace", when_namespace.name)
 
       local when_nested_namespace = tree[3][2][1]
       assert.is_not_nil(when_nested_namespace)
-      assert.equals("namespace", when_nested_namespace.type)
       assert.equals(
-        "nested `when` namespace should",
-        when_nested_namespace.name
+        wordspec_file
+          .. "::`when` namespace when::nested `when` namespace should",
+        when_nested_namespace.id
       )
+      assert.equals("namespace", when_nested_namespace.type)
+      assert.equals("nested `when` namespace", when_nested_namespace.name)
 
       local when_nested_namespace_pass_test = tree[3][2][2][1]
       assert.is_not_nil(when_nested_namespace_pass_test)
@@ -99,7 +110,7 @@ describe("treesitter", function()
       local should_namespace = tree[4][1]
       assert.is_not_nil(should_namespace)
       assert.equals("namespace", should_namespace.type)
-      assert.equals("namespace should", should_namespace.name)
+      assert.equals("namespace", should_namespace.name)
 
       local should_namespace_pass = tree[4][2][1]
       assert.is_not_nil(should_namespace_pass)

--- a/tests/treesitter/treesitter_spec.lua
+++ b/tests/treesitter/treesitter_spec.lua
@@ -29,6 +29,8 @@ describe("treesitter", function()
     vim.fs.joinpath(example_project_path, "KotestFeatureSpec.kt")
   local annotationspec_file =
     vim.fs.joinpath(example_project_path, "KotestAnnotationSpec.kt")
+  local wordspec_file =
+    vim.fs.joinpath(example_project_path, "KotestWordSpec.kt")
 
   describe("java_package", function()
     nio.tests.it("valid", function()
@@ -46,6 +48,70 @@ describe("treesitter", function()
   end)
 
   describe("parse_positions", function()
+    nio.tests.it("WordSpec", function()
+      local tree = treesitter.parse_positions(wordspec_file):to_list()
+      assert.equals("KotestWordSpec.kt", tree[1].name)
+      assert.equals("file", tree[1].type)
+
+      local When_namespace = tree[2][1]
+      assert.is_not_nil(When_namespace)
+      assert.equals("namespace", When_namespace.type)
+      assert.equals("When namespace when", When_namespace.name)
+
+      local When_nested_namespace = tree[2][2][1]
+      assert.is_not_nil(When_nested_namespace)
+      assert.equals("namespace", When_nested_namespace.type)
+      assert.equals("nested When namespace should", When_nested_namespace.name)
+
+      local When_nested_namespace_pass_test = tree[2][2][2][1]
+      assert.is_not_nil(When_nested_namespace_pass_test)
+      assert.equals("test", When_nested_namespace_pass_test.type)
+      assert.equals("pass", When_nested_namespace_pass_test.name)
+
+      local When_nested_namespace_fail_test = tree[2][2][3][1]
+      assert.is_not_nil(When_nested_namespace_fail_test)
+      assert.equals("test", When_nested_namespace_fail_test.type)
+      assert.equals("fail", When_nested_namespace_fail_test.name)
+
+      local when_namespace = tree[3][1]
+      assert.is_not_nil(when_namespace)
+      assert.equals("namespace", when_namespace.type)
+      assert.equals("`when` namespace when", when_namespace.name)
+
+      local when_nested_namespace = tree[3][2][1]
+      assert.is_not_nil(when_nested_namespace)
+      assert.equals("namespace", when_nested_namespace.type)
+      assert.equals(
+        "nested `when` namespace should",
+        when_nested_namespace.name
+      )
+
+      local when_nested_namespace_pass_test = tree[3][2][2][1]
+      assert.is_not_nil(when_nested_namespace_pass_test)
+      assert.equals("test", when_nested_namespace_pass_test.type)
+      assert.equals("pass", when_nested_namespace_pass_test.name)
+
+      local when_nested_namespace_fail_test = tree[3][2][3][1]
+      assert.is_not_nil(when_nested_namespace_fail_test)
+      assert.equals("test", when_nested_namespace_fail_test.type)
+      assert.equals("fail", when_nested_namespace_fail_test.name)
+
+      local should_namespace = tree[4][1]
+      assert.is_not_nil(should_namespace)
+      assert.equals("namespace", should_namespace.type)
+      assert.equals("namespace should", should_namespace.name)
+
+      local should_namespace_pass = tree[4][2][1]
+      assert.is_not_nil(should_namespace_pass)
+      assert.equals("test", should_namespace_pass.type)
+      assert.equals("pass", should_namespace_pass.name)
+
+      local should_namespace_fail = tree[4][3][1]
+      assert.is_not_nil(should_namespace_fail)
+      assert.equals("test", should_namespace_fail.type)
+      assert.equals("fail", should_namespace_fail.name)
+    end)
+
     nio.tests.it("StringSpec", function()
       local tree = treesitter.parse_positions(stringspec_file):to_list()
       assert.equals("KotestStringSpec.kt", tree[1].name)


### PR DESCRIPTION
Closes #11 
Succeeds #43 

This is a little gross, since we have to append on "when" and "should" based on the namespace. I have an idea in Neotest here where they allow us to provide an id rather than always using the name from `build_position`, I'll open a feature request to discuss that with them. That could allow us to change the id to match what we see in output, but not the name of the test. That'll be a future thing, doesn't block this

![word-spec-example](https://github.com/user-attachments/assets/6ee9749c-ac04-48e7-aa90-e2a2087c9a12)
