### PR TITLE
feat(file): added "files" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # neotest-kotlin
 
+<img src="./assets/icon-neotest-kotlin.svg" width="100" height="100" />
+
 This is an adapter for the neotest project. This gives you the ability to see and run your tests within neovim.
 
 ```lua

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/command/FindTestFiles.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/command/FindTestFiles.kt
@@ -1,0 +1,43 @@
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.split
+import com.github.ajalt.clikt.parameters.types.file
+import io.github.codymikol.kotlintest.extensions.getKtFiles
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.github.codymikol.kotlintest.files.model.FileCommandResult
+import io.github.codymikol.kotlintest.provider.Analysis
+import io.github.codymikol.kotlintest.provider.AnalysisApiSession
+import java.io.File
+
+public class Execute : CliktCommand() {
+
+    private val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    private val mapper by lazy { ObjectMapper().registerKotlinModule() }
+
+    private val files: List<File> by option(
+        help = "Comma separated test source absolute paths"
+    ).file(canBeDir = false).split(",").required()
+
+    private val output: File by option(help = "File to write the JSON test results").file().required()
+
+    override fun run() {
+
+        val session = AnalysisApiSession(
+            files = files.map { Analysis.File(it) },
+            unitTestMode = false
+        )
+
+        val ktFiles = session.kotlinFiles
+
+        val testFileResults = ktFiles.map(isTestContainingFileExecutor::getTestFileResult)
+
+        val fileCommandResult = FileCommandResult(testFileResults = testFileResults)
+
+        mapper.writeValue(output, fileCommandResult)
+
+    }
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/extensions/StandaloneAnlysisAPISessionExtensions.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/extensions/StandaloneAnlysisAPISessionExtensions.kt
@@ -1,0 +1,9 @@
+package io.github.codymikol.kotlintest.extensions
+
+import org.jetbrains.kotlin.analysis.api.standalone.StandaloneAnalysisAPISession
+import org.jetbrains.kotlin.psi.KtFile
+
+internal fun StandaloneAnalysisAPISession.getKtFiles(): List<KtFile> = modulesWithFiles
+    .values
+    .flatten()
+    .filterIsInstance<KtFile>()

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/IsTestContainingFileExecutor.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/IsTestContainingFileExecutor.kt
@@ -1,0 +1,43 @@
+package io.github.codymikol.kotlintest.files
+
+import io.github.codymikol.kotlintest.files.model.IsTestFileResult
+import io.github.codymikol.kotlintest.files.suite.junit.IsJunitTestContainingFile
+import io.github.codymikol.kotlintest.files.suite.kotest.IsKotestAnnotationSpecContainingFile
+import io.github.codymikol.kotlintest.files.suite.kotest.IsKotestBehaviorSpecContainingFile
+import io.github.codymikol.kotlintest.files.suite.kotest.IsKotestDescribeSpecContainingFile
+import io.github.codymikol.kotlintest.files.suite.kotest.IsKotestExpectSpecContainingFile
+import io.github.codymikol.kotlintest.files.suite.kotest.IsKotestFeatureSpecContainingFile
+import io.github.codymikol.kotlintest.files.suite.kotest.IsKotestFreeSpecContainingFile
+import io.github.codymikol.kotlintest.files.suite.kotest.IsKotestFunSpecContainingFile
+import io.github.codymikol.kotlintest.files.suite.kotest.IsKotestShouldSpecContainingFile
+import io.github.codymikol.kotlintest.files.suite.kotest.IsKotestStringSpecContainingFile
+import io.github.codymikol.kotlintest.files.suite.kotest.IsKotestWordSpecContainingFile
+import org.jetbrains.kotlin.psi.KtFile
+
+internal class IsTestContainingFileExecutor {
+
+    private val testTesters = listOf(
+        IsKotestAnnotationSpecContainingFile(),
+        IsKotestBehaviorSpecContainingFile(),
+        IsKotestDescribeSpecContainingFile(),
+        IsKotestExpectSpecContainingFile(),
+        IsKotestFeatureSpecContainingFile(),
+        IsKotestFreeSpecContainingFile(),
+        IsKotestFunSpecContainingFile(),
+        IsKotestShouldSpecContainingFile(),
+        IsJunitTestContainingFile(),
+        IsKotestStringSpecContainingFile(),
+        IsKotestWordSpecContainingFile(),
+    )
+
+    fun getTestFileResult(file: KtFile): IsTestFileResult {
+
+      val positiveResults = testTesters.filter { it.isTest(file) }
+
+        val typesOfTestsInFile = positiveResults.map { it.type }
+
+        return IsTestFileResult(types = typesOfTestsInFile, path = file.virtualFilePath)
+
+    }
+
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/model/FileCommandResult.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/model/FileCommandResult.kt
@@ -1,0 +1,5 @@
+package io.github.codymikol.kotlintest.files.model
+
+internal data class FileCommandResult(
+    val testFileResults: List<IsTestFileResult>
+)

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/model/IsTestFileResult.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/model/IsTestFileResult.kt
@@ -1,0 +1,12 @@
+package io.github.codymikol.kotlintest.files.model
+
+
+
+internal data class IsTestFileResult(
+    val path: String,
+    val types: List<TestFileType>
+) {
+
+    fun isTestFile(): Boolean = types.isNotEmpty()
+
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/model/TestFileType.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/model/TestFileType.kt
@@ -1,0 +1,15 @@
+package io.github.codymikol.kotlintest.files.model
+
+internal enum class TestFileType {
+    KotestAnnotationSpec,
+    KotestBehaviorSpec,
+    KotestDescribeSpec,
+    KotestExpectSpec,
+    KotestFeatureSpec,
+    KotestFreeSpec,
+    KotestFunSpec,
+    KotestShouldSpec,
+    KotestStringSpec,
+    KotestWordSpec,
+    JunitTest,
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/IsSubclassOfTest.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/IsSubclassOfTest.kt
@@ -1,0 +1,34 @@
+package io.github.codymikol.kotlintest.files.suite
+
+import com.intellij.psi.util.childrenOfType
+import io.github.codymikol.kotlintest.discover.kotest.getAllSuperClasses
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtSuperTypeListEntry
+import org.jetbrains.kotlin.psi.psiUtil.isAbstract
+
+internal class IsSubclassOfTest(val pkg: String, val identifier: String) {
+
+    private val testFqn = FqName("$pkg.$identifier")
+
+    fun evaluate(kotlinFile: KtFile): Boolean {
+        analyze(kotlinFile) {
+
+            val allClasses = kotlinFile.childrenOfType<KtClass>()
+
+            val concreteClasses = allClasses.filterNot(KtClass::isAbstract)
+
+            val superTypes = concreteClasses.flatMap(KtClass::getSuperTypeListEntries)
+
+            return superTypes.any(::canHandle)
+
+        }
+    }
+
+
+    private fun canHandle(superType: KtSuperTypeListEntry): Boolean = superType
+        .getAllSuperClasses().any { fqn -> fqn == testFqn }
+
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/IsTestContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/IsTestContainingFile.kt
@@ -1,0 +1,9 @@
+package io.github.codymikol.kotlintest.files.suite
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import org.jetbrains.kotlin.psi.KtFile
+
+internal interface IsTestContainingFile {
+    val type: TestFileType
+    fun isTest(kotlinFile: KtFile): Boolean
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/junit/IsJunitTestContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/junit/IsJunitTestContainingFile.kt
@@ -1,0 +1,13 @@
+package io.github.codymikol.kotlintest.files.suite.junit
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.files.suite.IsTestContainingFile
+import org.jetbrains.kotlin.psi.KtFile
+
+internal class IsJunitTestContainingFile : IsTestContainingFile {
+    override val type: TestFileType = TestFileType.JunitTest
+
+    override fun isTest(kotlinFile: KtFile): Boolean {
+        return false
+    }
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestAnnotationSpecContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestAnnotationSpecContainingFile.kt
@@ -1,0 +1,20 @@
+package io.github.codymikol.kotlintest.files.suite.kotest
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.files.suite.IsTestContainingFile
+import io.github.codymikol.kotlintest.files.suite.IsSubclassOfTest
+import org.jetbrains.kotlin.psi.KtFile
+
+
+internal class IsKotestAnnotationSpecContainingFile : IsTestContainingFile {
+
+    override val type: TestFileType = TestFileType.KotestAnnotationSpec
+
+    private val isKotestAnnotationSpecSubclass = IsSubclassOfTest(
+        pkg = "io.kotest.core.spec.style",
+        identifier = "AnnotationSpec",
+    )
+
+    override fun isTest(kotlinFile: KtFile): Boolean = isKotestAnnotationSpecSubclass.evaluate(kotlinFile)
+
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestBehaviorSpecContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestBehaviorSpecContainingFile.kt
@@ -1,0 +1,19 @@
+package io.github.codymikol.kotlintest.files.suite.kotest
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.files.suite.IsTestContainingFile
+import io.github.codymikol.kotlintest.files.suite.IsSubclassOfTest
+import org.jetbrains.kotlin.psi.KtFile
+
+internal class IsKotestBehaviorSpecContainingFile : IsTestContainingFile {
+
+    override val type: TestFileType = TestFileType.KotestBehaviorSpec
+
+    private val isKotestBehaviorSpecSubclass = IsSubclassOfTest(
+        pkg = "io.kotest.core.spec.style",
+        identifier = "BehaviorSpec",
+    )
+
+    override fun isTest(kotlinFile: KtFile): Boolean = isKotestBehaviorSpecSubclass.evaluate(kotlinFile)
+
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestDescribeSpecContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestDescribeSpecContainingFile.kt
@@ -1,0 +1,19 @@
+package io.github.codymikol.kotlintest.files.suite.kotest
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.files.suite.IsTestContainingFile
+import io.github.codymikol.kotlintest.files.suite.IsSubclassOfTest
+import org.jetbrains.kotlin.psi.KtFile
+
+internal class IsKotestDescribeSpecContainingFile : IsTestContainingFile {
+
+    override val type: TestFileType = TestFileType.KotestDescribeSpec
+
+    private val isKotestDescribeSpecSubclass = IsSubclassOfTest(
+        pkg = "io.kotest.core.spec.style",
+        identifier = "DescribeSpec",
+    )
+
+    override fun isTest(kotlinFile: KtFile): Boolean = isKotestDescribeSpecSubclass.evaluate(kotlinFile)
+
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestExpectSpecContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestExpectSpecContainingFile.kt
@@ -1,0 +1,20 @@
+package io.github.codymikol.kotlintest.files.suite.kotest
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.files.suite.IsTestContainingFile
+import io.github.codymikol.kotlintest.files.suite.IsSubclassOfTest
+import org.jetbrains.kotlin.psi.KtFile
+
+internal class IsKotestExpectSpecContainingFile : IsTestContainingFile {
+
+    override val type: TestFileType = TestFileType.KotestExpectSpec
+
+    private val isKotestExpectSpecSubclass = IsSubclassOfTest(
+        pkg = "io.kotest.core.spec.style",
+        identifier = "ExpectSpec",
+    )
+
+    override fun isTest(kotlinFile: KtFile): Boolean = isKotestExpectSpecSubclass.evaluate(kotlinFile)
+
+
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestFeatureSpecContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestFeatureSpecContainingFile.kt
@@ -1,0 +1,19 @@
+package io.github.codymikol.kotlintest.files.suite.kotest
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.files.suite.IsTestContainingFile
+import io.github.codymikol.kotlintest.files.suite.IsSubclassOfTest
+import org.jetbrains.kotlin.psi.KtFile
+
+internal class IsKotestFeatureSpecContainingFile : IsTestContainingFile {
+
+    override val type: TestFileType = TestFileType.KotestFeatureSpec
+
+    private val isKotestFeatureSpecSubclass = IsSubclassOfTest(
+        pkg = "io.kotest.core.spec.style",
+        identifier = "FeatureSpec",
+    )
+
+    override fun isTest(kotlinFile: KtFile): Boolean = isKotestFeatureSpecSubclass.evaluate(kotlinFile)
+
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestFreeSpecContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestFreeSpecContainingFile.kt
@@ -1,0 +1,17 @@
+package io.github.codymikol.kotlintest.files.suite.kotest
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.files.suite.IsTestContainingFile
+import io.github.codymikol.kotlintest.files.suite.IsSubclassOfTest
+import org.jetbrains.kotlin.psi.KtFile
+
+internal class IsKotestFreeSpecContainingFile : IsTestContainingFile {
+    override val type: TestFileType = TestFileType.KotestFreeSpec
+
+    private val isKotestFreeSpecSubclass = IsSubclassOfTest(
+        pkg = "io.kotest.core.spec.style",
+        identifier = "FreeSpec",
+    )
+
+    override fun isTest(kotlinFile: KtFile): Boolean = isKotestFreeSpecSubclass.evaluate(kotlinFile)
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestFunSpecContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestFunSpecContainingFile.kt
@@ -1,0 +1,19 @@
+package io.github.codymikol.kotlintest.files.suite.kotest
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.files.suite.IsTestContainingFile
+import io.github.codymikol.kotlintest.files.suite.IsSubclassOfTest
+import org.jetbrains.kotlin.psi.KtFile
+
+internal class IsKotestFunSpecContainingFile : IsTestContainingFile {
+
+    override val type: TestFileType = TestFileType.KotestFunSpec
+
+    private val isKotestFunSpecSubclass = IsSubclassOfTest(
+        pkg = "io.kotest.core.spec.style",
+        identifier = "FunSpec",
+    )
+
+    override fun isTest(kotlinFile: KtFile): Boolean = isKotestFunSpecSubclass.evaluate(kotlinFile)
+
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestShouldSpecContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestShouldSpecContainingFile.kt
@@ -1,0 +1,17 @@
+package io.github.codymikol.kotlintest.files.suite.kotest
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.files.suite.IsTestContainingFile
+import io.github.codymikol.kotlintest.files.suite.IsSubclassOfTest
+import org.jetbrains.kotlin.psi.KtFile
+
+internal class IsKotestShouldSpecContainingFile: IsTestContainingFile {
+    override val type: TestFileType = TestFileType.KotestShouldSpec
+
+    private val isKotestShouldSpecSubclass = IsSubclassOfTest(
+        pkg = "io.kotest.core.spec.style",
+        identifier = "ShouldSpec",
+    )
+
+    override fun isTest(kotlinFile: KtFile): Boolean = isKotestShouldSpecSubclass.evaluate(kotlinFile)
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestStringSpecContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestStringSpecContainingFile.kt
@@ -1,0 +1,18 @@
+package io.github.codymikol.kotlintest.files.suite.kotest
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.files.suite.IsTestContainingFile
+import io.github.codymikol.kotlintest.files.suite.IsSubclassOfTest
+import org.jetbrains.kotlin.psi.KtFile
+
+internal class IsKotestStringSpecContainingFile : IsTestContainingFile {
+
+    override val type: TestFileType = TestFileType.KotestStringSpec
+
+    private val isKotestStringSpecSubclass = IsSubclassOfTest(
+        pkg = "io.kotest.core.spec.style",
+        identifier = "StringSpec",
+    )
+
+    override fun isTest(kotlinFile: KtFile): Boolean = isKotestStringSpecSubclass.evaluate(kotlinFile)
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestWordSpecContainingFile.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/files/suite/kotest/IsKotestWordSpecContainingFile.kt
@@ -1,0 +1,17 @@
+package io.github.codymikol.kotlintest.files.suite.kotest
+
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.files.suite.IsTestContainingFile
+import io.github.codymikol.kotlintest.files.suite.IsSubclassOfTest
+import org.jetbrains.kotlin.psi.KtFile
+
+internal class IsKotestWordSpecContainingFile : IsTestContainingFile {
+    override val type: TestFileType = TestFileType.KotestWordSpec
+
+    private val isKotestWordSpecSubclass = IsSubclassOfTest(
+        pkg = "io.kotest.core.spec.style",
+        identifier = "WordSpec",
+    )
+
+    override fun isTest(kotlinFile: KtFile): Boolean = isKotestWordSpecSubclass.evaluate(kotlinFile)
+}

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/provider/AnalysisApiSession.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/provider/AnalysisApiSession.kt
@@ -55,9 +55,9 @@ internal class AnalysisApiSession(
             .values
             .flatten()
             // Filter out stubs that aren't real tests
-            .filter {
+            .filter { it ->
                 it.name !in listOf(
-                    kotestStubImplVirtualFile().name,
+                    KotestStubVirtualFileName,
                     junitImplVirtualFiles().map { it.name }
                 )
             }

--- a/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/provider/KotestStubVirtualFileProvider.kt
+++ b/kotlin-test/core/src/main/kotlin/io/github/codymikol/kotlintest/provider/KotestStubVirtualFileProvider.kt
@@ -5,21 +5,23 @@ import org.jetbrains.kotlin.idea.KotlinLanguage
 
 private val mockKotestApi = """
        package io.kotest.core.spec.style
+       
+       public open class AnnotationSpec {}
+       public open class BehaviorSpec {}
+       public open class DescribeSpec {}
+       public open class ExpectSpec {}
+       public open class FeatureSpec {}
+       public open class FreeSpec {}
+       public open class FunSpec {}
+       public open class ShouldSpec {}
+       public open class StringSpec {}
+       public open class WordSpec {}
+    """.trimIndent()
 
-        class AnnotationSpec
-        class BehaviorSpec
-        class DescribeSpec
-        class ExpectSpec
-        class FeatureSpec
-        class FreeSpec
-        class FunSpec
-        class ShouldSpec
-        class StringSpec
-        class WordSpec
-""".trimIndent()
+internal const val KotestStubVirtualFileName = "Kotest.kt"
 
 internal fun kotestStubImplVirtualFile(): LightVirtualFile = LightVirtualFile(
-    "Kotest.kt",
+    KotestStubVirtualFileName,
     KotlinLanguage.INSTANCE,
     mockKotestApi
 )

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/junit/files/IsJunitContainingFileFunctionalSpec.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/junit/files/IsJunitContainingFileFunctionalSpec.kt
@@ -1,0 +1,42 @@
+package io.github.codymikol.kotlintest.junit.files
+
+import io.github.codymikol.kotlintest.createKtFile
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.collections.shouldBeEmpty
+import org.intellij.lang.annotations.Language
+
+class IsJunitContainingFileFunctionalSpec : FunSpec({
+
+    val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    context("When a file doesn't contain a Junit Test") {
+
+        @Language("kotlin")
+        val ktFile = createKtFile(
+            "ExampleJunitTest.kt",
+            """
+                package org.example
+                            
+                class Foo {
+                  // big mood
+                } 
+            """.trimIndent()
+        )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is NOT a test file") {
+            result.isTestFile().shouldBeFalse()
+        }
+
+        test("that the correct file types are reported") {
+            result.types.shouldBeEmpty()
+        }
+
+    }
+
+    context("When a file contains a subclassed ")
+
+})

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/KotestSubclassLightweightFileFactory.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/KotestSubclassLightweightFileFactory.kt
@@ -1,0 +1,33 @@
+package io.github.codymikol.kotlintest.kotest
+
+import com.intellij.testFramework.LightVirtualFile
+import io.github.codymikol.kotlintest.provider.Analysis
+import org.jetbrains.kotlin.idea.KotlinLanguage
+
+private val mockKotestSubclassApi = """
+       package io.kotest.core.spec.style
+       
+       public class AnnotationSpecSubclass : AnnotationSpec() {}
+       public class BehaviorSpecSubclass : BehaviorSpec() {}
+       public class DescribeSpecSubclass : DescribeSpec() {}
+       public class ExpectSpecSubclass : ExpectSpec() {}
+       public class FeatureSpecSubclass : FeatureSpec() {}
+       public class FreeSpecSubclass : FreeSpec() {}
+       public class FunSpecSubclass : FunSpec() {}
+       public class ShouldSpecSubclass : ShouldSpec() {}
+       public class StringSpecSubclass : StringSpec() {}
+       public class WordSpecSubclass : WordSpec() {}
+    """.trimIndent()
+
+internal const val KotestStubSubclassVirtualFileName = "KotestSubclass.kt"
+
+internal fun kotestSubclassAnalysis() = Analysis.VirtualFile(
+    KotestStubSubclassVirtualFileName,
+    mockKotestSubclassApi
+)
+
+internal fun kotestSubclassVirtualFile(): LightVirtualFile = LightVirtualFile(
+    KotestStubSubclassVirtualFileName,
+    KotlinLanguage.INSTANCE,
+    mockKotestSubclassApi
+)

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestAnnotationSpecContainingFileFunctionalSpec.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestAnnotationSpecContainingFileFunctionalSpec.kt
@@ -1,0 +1,117 @@
+package io.github.codymikol.kotlintest.kotest.files
+
+import io.github.codymikol.kotlintest.createKtFile
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.kotest.kotestSubclassAnalysis
+import io.github.codymikol.kotlintest.provider.Analysis
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
+
+class IsKotestAnnotationSpecContainingFileFunctionalSpec : FunSpec({
+
+    val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    val kotestSubclassAnalysis = kotestSubclassAnalysis()
+
+    context("When a file doesn't contain an AnnotationSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleAnnotationSpec.kt",
+
+                """
+                        package org.example
+                                
+                        class Foo {
+                          // big mood
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is NOT a test file") {
+           result.isTestFile().shouldBeFalse()
+        }
+
+        test("The correct file types are reported") {
+            result.types.shouldBeEmpty()
+        }
+
+    }
+
+    context("When a file contains an AnnotationSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleAnnotationSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.AnnotationSpec
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleAnnotationSpec : AnnotationSpec() {
+                            @Test
+                            fun example() {
+                                1 shouldBe 1
+                            }
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestAnnotationSpec)
+        }
+    }
+
+    context("When a file contains a subclassed AnnotationSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleAnnotationSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.AnnotationSpec
+                        import io.kotest.core.spec.style.AnnotationSpecSubclass
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleAnnotationSpec : AnnotationSpecSubclass() {
+                            @Test
+                            fun example() {
+                                1 shouldBe 1
+                            }
+                        }
+                        """.trimIndent(),
+                dependencies = listOf(kotestSubclassAnalysis) as Collection<Analysis>
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestAnnotationSpec)
+        }
+
+    }
+
+})

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestBehaviorSpecContainingFileFunctionalSpec.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestBehaviorSpecContainingFileFunctionalSpec.kt
@@ -1,0 +1,134 @@
+package io.github.codymikol.kotlintest.kotest.files
+
+import io.github.codymikol.kotlintest.createKtFile
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.kotest.kotestSubclassAnalysis
+import io.github.codymikol.kotlintest.provider.Analysis
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
+
+class IsKotestBehaviorSpecContainingFileFunctionalSpec : FunSpec({
+
+    val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    val kotestSubclassAnalysis = kotestSubclassAnalysis()
+
+    context("When a file doesn't contain a BehaviorSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleBehaviorSpec.kt",
+
+                """
+                        package org.example
+                                
+                        class Foo {
+                          // big mood
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is NOT a test file") {
+            result.isTestFile().shouldBeFalse()
+        }
+
+        test("The correct file types are reported") {
+            result.types.shouldBeEmpty()
+        }
+
+    }
+
+    context("When a file contains a BehaviorSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleBehaviorSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.BehaviorSpec
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleBehaviorSpec : BehaviorSpec() {
+                          
+                            init {
+                                Context("Context") {
+                                    Given("Given") {
+                                        When("When") {
+                                            Then("Then") {
+                                                1 shouldBe 1
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestBehaviorSpec)
+        }
+    }
+
+    context("When a file contains a subclassed BehaviorSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleBehaviorSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.BehaviorSpec
+                        import io.kotest.core.spec.style.BehaviorSpecSubclass
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleBehaviorSpec : BehaviorSpecSubclass() {
+                        
+                            init {
+                                Context("Context") {
+                                    Given("Given") {
+                                        When("When") {
+                                            Then("Then") {
+                                                1 shouldBe 1
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            
+                        }
+                        """.trimIndent(),
+                dependencies = listOf(kotestSubclassAnalysis) as Collection<Analysis>
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestBehaviorSpec)
+        }
+
+    }
+
+})

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestDescribeSpecContainingFileFunctionalSpec.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestDescribeSpecContainingFileFunctionalSpec.kt
@@ -1,0 +1,119 @@
+package io.github.codymikol.kotlintest.kotest.files
+
+import io.github.codymikol.kotlintest.createKtFile
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.kotest.kotestSubclassAnalysis
+import io.github.codymikol.kotlintest.provider.Analysis
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
+
+class IsKotestDescribeSpecContainingFileFunctionalSpec : FunSpec({
+
+    val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    val kotestSubclassAnalysis = kotestSubclassAnalysis()
+
+    context("When a file doesn't contain a DescribeSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleDescribeSpec.kt",
+
+                """
+                        package org.example
+                                
+                        class Foo {
+                          // big mood
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is NOT a test file") {
+            result.isTestFile().shouldBeFalse()
+        }
+
+        test("The correct file types are reported") {
+            result.types.shouldBeEmpty()
+        }
+
+    }
+
+    context("When a file contains a DescribeSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleDescribeSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.DescribeSpec
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleDescribeSpec : DescribeSpec() {
+                            init {
+                                it("test") {
+                                  1 shouldBe 1
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestDescribeSpec)
+        }
+    }
+
+    context("When a file contains a subclassed DescribeSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleDescribeSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.DescribeSpec
+                        import io.kotest.core.spec.style.DescribeSpecSubclass
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleDescribeSpec : DescribeSpecSubclass() {
+                            init {
+                                it("test") {
+                                  1 shouldBe 1
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                dependencies = listOf(kotestSubclassAnalysis) as Collection<Analysis>
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestDescribeSpec)
+        }
+
+    }
+
+})

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestExpectSpecContainingFileFunctionalSpec.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestExpectSpecContainingFileFunctionalSpec.kt
@@ -1,0 +1,119 @@
+package io.github.codymikol.kotlintest.kotest.files
+
+import io.github.codymikol.kotlintest.createKtFile
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.kotest.kotestSubclassAnalysis
+import io.github.codymikol.kotlintest.provider.Analysis
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
+
+class IsKotestExpectSpecContainingFileFunctionalSpec : FunSpec({
+
+    val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    val kotestSubclassAnalysis = kotestSubclassAnalysis()
+
+    context("When a file doesn't contain a ExpectSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleExpectSpec.kt",
+
+                """
+                        package org.example
+                                
+                        class Foo {
+                          // big mood
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is NOT a test file") {
+            result.isTestFile().shouldBeFalse()
+        }
+
+        test("The correct file types are reported") {
+            result.types.shouldBeEmpty()
+        }
+
+    }
+
+    context("When a file contains a ExpectSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleExpectSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.ExpectSpec
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleExpectSpec : ExpectSpec() {
+                            init {
+                                expect("test") {
+                                  1 shouldBe 1
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestExpectSpec)
+        }
+    }
+
+    context("When a file contains a subclassed ExpectSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleExpectSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.ExpectSpec
+                        import io.kotest.core.spec.style.ExpectSpecSubclass
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleExpectSpec : ExpectSpecSubclass() {
+                            init {
+                                expect("test") {
+                                  1 shouldBe 1
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                dependencies = listOf(kotestSubclassAnalysis) as Collection<Analysis>
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestExpectSpec)
+        }
+
+    }
+
+})

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestFeatureSpecContainingFileFunctionalSpec.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestFeatureSpecContainingFileFunctionalSpec.kt
@@ -1,0 +1,119 @@
+package io.github.codymikol.kotlintest.kotest.files
+
+import io.github.codymikol.kotlintest.createKtFile
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.kotest.kotestSubclassAnalysis
+import io.github.codymikol.kotlintest.provider.Analysis
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
+
+class IsKotestFeatureSpecContainingFileFunctionalSpec : FunSpec({
+
+    val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    val kotestSubclassAnalysis = kotestSubclassAnalysis()
+
+    context("When a file doesn't contain a FeatureSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleFeatureSpec.kt",
+
+                """
+                        package org.example
+                                
+                        class Foo {
+                          // big mood
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is NOT a test file") {
+            result.isTestFile().shouldBeFalse()
+        }
+
+        test("The correct file types are reported") {
+            result.types.shouldBeEmpty()
+        }
+
+    }
+
+    context("When a file contains a FeatureSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleFeatureSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.FeatureSpec
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleFeatureSpec : FeatureSpec() {
+                            init {
+                                scenario("test") {
+                                  1 shouldBe 1
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestFeatureSpec)
+        }
+    }
+
+    context("When a file contains a subclassed FeatureSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleFeatureSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.FeatureSpec
+                        import io.kotest.core.spec.style.FeatureSpecSubclass
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleFeatureSpec : FeatureSpecSubclass() {
+                            init {
+                                scenario("test") {
+                                  1 shouldBe 1
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                dependencies = listOf(kotestSubclassAnalysis) as Collection<Analysis>
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestFeatureSpec)
+        }
+
+    }
+
+})

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestFreeSpecContainingFileFunctionalSpec.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestFreeSpecContainingFileFunctionalSpec.kt
@@ -1,0 +1,119 @@
+package io.github.codymikol.kotlintest.kotest.files
+
+import io.github.codymikol.kotlintest.createKtFile
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.kotest.kotestSubclassAnalysis
+import io.github.codymikol.kotlintest.provider.Analysis
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
+
+class IsKotestFreeSpecContainingFileFunctionalSpec : FunSpec({
+
+    val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    val kotestSubclassAnalysis = kotestSubclassAnalysis()
+
+    context("When a file doesn't contain a FreeSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleFreeSpec.kt",
+
+                """
+                        package org.example
+                                
+                        class Foo {
+                          // big mood
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is NOT a test file") {
+            result.isTestFile().shouldBeFalse()
+        }
+
+        test("The correct file types are reported") {
+            result.types.shouldBeEmpty()
+        }
+
+    }
+
+    context("When a file contains a FreeSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleFreeSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.FreeSpec
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleFreeSpec : FreeSpec() {
+                            init {
+                                "example string" {
+                                    1 shouldBe 1
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestFreeSpec)
+        }
+    }
+
+    context("When a file contains a subclassed FreeSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleFreeSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.FreeSpec
+                        import io.kotest.core.spec.style.FreeSpecSubclass
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleFreeSpec : FreeSpecSubclass() {
+                            init {
+                                "example string" {
+                                    1 shouldBe 1
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                dependencies = listOf(kotestSubclassAnalysis) as Collection<Analysis>
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestFreeSpec)
+        }
+
+    }
+
+})

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestFunSpecContainingFileFunctionalSpec.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestFunSpecContainingFileFunctionalSpec.kt
@@ -1,0 +1,119 @@
+package io.github.codymikol.kotlintest.kotest.files
+
+import io.github.codymikol.kotlintest.createKtFile
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.kotest.kotestSubclassAnalysis
+import io.github.codymikol.kotlintest.provider.Analysis
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
+
+class IsKotestFunSpecContainingFileFunctionalSpec : FunSpec({
+
+    val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    val kotestSubclassAnalysis = kotestSubclassAnalysis()
+
+    context("When a file doesn't contain a FunSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleFunSpec.kt",
+
+                """
+                        package org.example
+                                
+                        class Foo {
+                          // big mood
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is NOT a test file") {
+            result.isTestFile().shouldBeFalse()
+        }
+
+        test("The correct file types are reported") {
+            result.types.shouldBeEmpty()
+        }
+
+    }
+
+    context("When a file contains a FunSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleFunSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.FunSpec
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleFunSpec : FunSpec({
+                            context("f:namespace") {
+                                test("test") {
+                                  1 shouldBe 1
+                                }
+                            }
+                        })
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestFunSpec)
+        }
+    }
+
+    context("When a file contains a subclassed FunSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleFunSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.FunSpec
+                        import io.kotest.core.spec.style.FunSpecSubclass
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleFunSpec : FunSpecSubclass({
+                            context("f:namespace") {
+                                test("test") {
+                                  1 shouldBe 1
+                                }
+                            }
+                        })
+                        """.trimIndent(),
+                dependencies = listOf(kotestSubclassAnalysis) as Collection<Analysis>
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestFunSpec)
+        }
+
+    }
+
+})

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestShouldSpecContainingFileFunctionalSpec.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestShouldSpecContainingFileFunctionalSpec.kt
@@ -1,0 +1,151 @@
+package io.github.codymikol.kotlintest.kotest.files
+
+import io.github.codymikol.kotlintest.createKtFile
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.kotest.kotestSubclassAnalysis
+import io.github.codymikol.kotlintest.provider.Analysis
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
+
+class IsKotestShouldSpecContainingFileFunctionalSpec : FunSpec({
+
+    val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    val kotestSubclassAnalysis = kotestSubclassAnalysis()
+
+    context("When a file doesn't contain a ShouldSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleShouldSpec.kt",
+
+                """
+                        package org.example
+                                
+                        class Foo {
+                          // big mood
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is NOT a test file") {
+            result.isTestFile().shouldBeFalse()
+        }
+
+        test("The correct file types are reported") {
+            result.types.shouldBeEmpty()
+        }
+
+    }
+
+    context("When a file contains a ShouldSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleShouldSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.ShouldSpec
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleShouldSpec : ShouldSpec({
+                            context("container1") {
+                                should("should1") {
+                                    1 shouldBe 1
+                                }
+                            }
+                            
+                            context("container2") {
+                                context("container3") {
+                                    should("should2") {
+                                        1 shouldBe 1
+                                    }
+                                }
+                                
+                                should("should3") {
+                                    1 shouldBe 1
+                                }
+                            }
+                            
+                            should("should4") {
+                              1 shouldBe 1
+                            }
+                        })
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestShouldSpec)
+        }
+    }
+
+    context("When a file contains a subclassed ShouldSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleShouldSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.ShouldSpec
+                        import io.kotest.core.spec.style.ShouldSpecSubclass
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleShouldSpec : ShouldSpecSubclass({
+                            context("container1") {
+                                should("should1") {
+                                    1 shouldBe 1
+                                }
+                            }
+                            
+                            context("container2") {
+                                context("container3") {
+                                    should("should2") {
+                                        1 shouldBe 1
+                                    }
+                                }
+                                
+                                should("should3") {
+                                    1 shouldBe 1
+                                }
+                            }
+                            
+                            should("should4") {
+                              1 shouldBe 1
+                            }
+                        })
+                        """.trimIndent(),
+                dependencies = listOf(kotestSubclassAnalysis) as Collection<Analysis>
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestShouldSpec)
+        }
+
+    }
+
+})

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestStringSpecContainingFileFunctionalSpec.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestStringSpecContainingFileFunctionalSpec.kt
@@ -1,0 +1,118 @@
+package io.github.codymikol.kotlintest.kotest.files
+
+import io.github.codymikol.kotlintest.createKtFile
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.kotest.kotestSubclassAnalysis
+import io.github.codymikol.kotlintest.provider.Analysis
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
+
+class IsKotestStringSpecContainingFileFunctionalSpec : FunSpec({
+
+    val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    val kotestSubclassAnalysis = kotestSubclassAnalysis()
+
+    context("When a file doesn't contain a StringSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleStringSpec.kt",
+
+                """
+                        package org.example
+                                
+                        class Foo {
+                          // big mood
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is NOT a test file") {
+            result.isTestFile().shouldBeFalse()
+        }
+
+        test("The correct file types are reported") {
+            result.types.shouldBeEmpty()
+        }
+
+    }
+
+    context("When a file contains a StringSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleStringSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.StringSpec
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleStringSpec : StringSpec() {
+                            init {
+                                "example string" {
+                                    1 shouldBe 1
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestStringSpec)
+        }
+    }
+
+    context("When a file contains a subclassed StringSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleStringSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.StringSpec
+                        import io.kotest.core.spec.style.StringSpecSubclass
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleStringSpec : StringSpecSubclass() {
+                            init {
+                                "example string" {
+                                    1 shouldBe 1
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                dependencies = listOf(kotestSubclassAnalysis) as Collection<Analysis>
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestStringSpec)
+        }
+
+    }
+
+})

--- a/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestWordSpecContainingFileFunctionalSpec.kt
+++ b/kotlin-test/core/src/test/kotlin/io/github/codymikol/kotlintest/kotest/files/IsKotestWordSpecContainingFileFunctionalSpec.kt
@@ -1,0 +1,114 @@
+package io.github.codymikol.kotlintest.kotest.files
+
+import io.github.codymikol.kotlintest.createKtFile
+import io.github.codymikol.kotlintest.files.IsTestContainingFileExecutor
+import io.github.codymikol.kotlintest.files.model.TestFileType
+import io.github.codymikol.kotlintest.kotest.kotestSubclassAnalysis
+import io.github.codymikol.kotlintest.provider.Analysis
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
+
+class IsKotestWordSpecContainingFileFunctionalSpec : FunSpec({
+
+    val isTestContainingFileExecutor = IsTestContainingFileExecutor()
+
+    val kotestSubclassAnalysis = kotestSubclassAnalysis()
+
+    context("When a file doesn't contain a WordSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleWordSpec.kt",
+
+                """
+                        package org.example
+                                
+                        class Foo {
+                          // big mood
+                        }
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is NOT a test file") {
+            result.isTestFile().shouldBeFalse()
+        }
+
+        test("The correct file types are reported") {
+            result.types.shouldBeEmpty()
+        }
+
+    }
+
+    context("When a file contains a WordSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleWordSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.WordSpec
+                        import io.kotest.matchers.shouldBe
+                        
+                        class ExampleWordSpec : WordSpec({
+                            "example string" {
+                                1 shouldBe 1
+                            }
+                        })
+                        """.trimIndent(),
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestWordSpec)
+        }
+    }
+
+    context("When a file contains a subclassed WordSpec test") {
+
+        @Language("kotlin")
+        val ktFile =
+            createKtFile(
+                "ExampleWordSpec.kt",
+                """
+                        package org.example
+                                
+                        import io.kotest.core.spec.style.WordSpecSubclass
+                        import io.kotest.matchers.shouldBe
+
+                        
+                        class ExampleWordSpec : WordSpecSubclass({
+                            "example string" {
+                                1 shouldBe 1
+                            }
+                        })
+                        """.trimIndent(),
+                dependencies = listOf(kotestSubclassAnalysis) as Collection<Analysis>
+            )
+
+        val result = isTestContainingFileExecutor.getTestFileResult(ktFile)
+
+        test("that the result is a test file") {
+            result.isTestFile().shouldBeTrue()
+        }
+
+        test("The correct file types are reported") {
+            result.types shouldBe listOf(TestFileType.KotestWordSpec)
+        }
+
+    }
+
+})

--- a/kotlin-test/gradle-plugin/src/main/kotlin/io/github/codymikol/kotlintest/plugin/task/KotlinTestFindTestsTask.kt
+++ b/kotlin-test/gradle-plugin/src/main/kotlin/io/github/codymikol/kotlintest/plugin/task/KotlinTestFindTestsTask.kt
@@ -1,0 +1,37 @@
+package io.github.codymikol.kotlintest.plugin.task
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.OutputFile
+
+abstract class KotlinTestFindTestsTask : JavaExec() {
+
+    companion object {
+        const val MAIN = "io.github.codymikol.kotlintest.MainKt"
+    }
+
+    @get:InputFiles
+    abstract val allFilesInTestSource: ConfigurableFileCollection
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    override fun exec() {
+
+        val outputFile = this@KotlinTestFindTestsTask.outputFile.asFile.get()
+
+        println("Executing: $MAIN files --output=$outputFile")
+
+        this.args(
+            listOf(
+                "files",
+                "--files=${allFilesInTestSource.joinToString(",") { it.absolutePath }}",
+                "--output=$outputFile",
+            ),
+        )
+
+        super.exec()
+    }
+}


### PR DESCRIPTION
this command can take in a list of source files
and will determine which test suites
are being used within the file.

At the moment, only kotest is fully supported.
some additional work is needed for junit that
will be addressed in a follow up commit.

Fixes N/A